### PR TITLE
fix: use portable shebang for NixOS compatibility

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ============================================
 # Ralphy - Autonomous AI Coding Loop


### PR DESCRIPTION
Updates the shebang to use env for better portability across different distributions, specifically NixOS.