### PR TITLE
fix: Prevent script exit on arithmetic increment when variable is 0

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -1162,7 +1162,7 @@ run_single_task() {
 
     # Check for empty response
     if [[ -z "$result" ]]; then
-      ((retry_count++))
+      ((retry_count++)) || true
       log_error "Empty response (attempt $retry_count/$MAX_RETRIES)"
       if [[ $retry_count -lt $MAX_RETRIES ]]; then
         log_info "Retrying in ${RETRY_DELAY}s..."
@@ -1178,7 +1178,7 @@ run_single_task() {
     # Check for API errors
     local error_msg
     if ! error_msg=$(check_for_errors "$result"); then
-      ((retry_count++))
+      ((retry_count++)) || true
       log_error "API error: $error_msg (attempt $retry_count/$MAX_RETRIES)"
       if [[ $retry_count -lt $MAX_RETRIES ]]; then
         log_info "Retrying in ${RETRY_DELAY}s..."
@@ -1456,7 +1456,7 @@ Focus only on implementing: $task_name"
     if [[ -n "$result" ]]; then
       local error_msg
       if ! error_msg=$(check_for_errors "$result"); then
-        ((retry++))
+        ((retry++)) || true
         echo "API error: $error_msg (attempt $retry/$MAX_RETRIES)" >> "$log_file"
         sleep "$RETRY_DELAY"
         continue
@@ -1465,7 +1465,7 @@ Focus only on implementing: $task_name"
       break
     fi
     
-    ((retry++))
+    ((retry++)) || true
     echo "Retry $retry/$MAX_RETRIES after empty response" >> "$log_file"
     sleep "$RETRY_DELAY"
   done
@@ -1593,7 +1593,7 @@ run_parallel_tasks() {
     local total_group_tasks=${#tasks[@]}
 
     while [[ $batch_start -lt $total_group_tasks ]]; do
-      ((batch_num++))
+      ((batch_num++)) || true
       local batch_end=$((batch_start + MAX_PARALLEL))
       [[ $batch_end -gt $total_group_tasks ]] && batch_end=$total_group_tasks
       local batch_size=$((batch_end - batch_start))
@@ -1616,7 +1616,7 @@ run_parallel_tasks() {
       for ((i = batch_start; i < batch_end; i++)); do
         local task="${tasks[$i]}"
         local agent_num=$((iteration + 1))
-        ((iteration++))
+        ((iteration++)) || true
 
         local status_file=$(mktemp)
         local output_file=$(mktemp)
@@ -1662,17 +1662,17 @@ run_parallel_tasks() {
           case "$status" in
             "setting up")
               all_done=false
-              ((setting_up++))
+              ((setting_up++)) || true
               ;;
             running)
               all_done=false
-              ((running++))
+              ((running++)) || true
               ;;
             done)
-              ((done_count++))
+              ((done_count++)) || true
               ;;
             failed)
-              ((failed_count++))
+              ((failed_count++)) || true
               ;;
             *)
               # Check if process is still running
@@ -2068,7 +2068,7 @@ main() {
 
   # Sequential main loop
   while true; do
-    ((iteration++))
+    ((iteration++)) || true
     local result_code=0
     run_single_task "" "$iteration" || result_code=$?
     


### PR DESCRIPTION
With `set -e`, `((var++))` returns exit code 1 when var is 0 (since the expression evaluates to 0/falsy), causing unexpected script termination.

Fixed all 11 instances by adding `|| true`:
- Line 1165, 1181: retry_count++ in run_single_task
- Line 1459, 1468: retry++ in run_parallel_agent
- Line 1596: batch_num++ in run_parallel_tasks
- Line 1619: iteration++ in parallel batch loop
- Line 1665, 1669, 1672, 1675: status counters in progress monitor
- Line 2071: iteration++ in sequential main loop