### PR TITLE
feat: Add single-task mode and project config

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -181,13 +181,11 @@ init_ralphy_config() {
     local scripts
     scripts=$(jq -r '.scripts // {}' package.json 2>/dev/null)
 
-    # Test command
+    # Test command (prefer bun if lockfile exists)
     if echo "$scripts" | jq -e '.test' >/dev/null 2>&1; then
       test_cmd="npm test"
+      [[ -f "bun.lockb" ]] && test_cmd="bun test"
     fi
-    echo "$deps" | grep -qx "vitest" && test_cmd="npm test"
-    echo "$deps" | grep -qx "jest" && test_cmd="npm test"
-    [[ -f "bun.lockb" ]] && test_cmd="bun test"
 
     # Lint command
     if echo "$scripts" | jq -e '.lint' >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
  - Run quick tasks without a PRD: `ralphy "add dark mode"`
  - New `.ralphy/` folder stores project context, rules, and task history
  - Auto-detects language, framework, and npm scripts on `--init`
  - Config applies to both quick tasks and PRD loop mode

  ## New Commands
  | Command | Description |
  |---------|-------------|
  | `ralphy "task"` | Run a single task |
  | `ralphy --init` | Setup project config with smart defaults |
  | `ralphy --config` | View current config |
  | `ralphy --add-rule "..."` | Add a rule the AI must follow |
  | `ralphy --no-commit` | Skip auto-commit |

  ## Breaking Changes
  None. Existing PRD workflows work exactly as before.