### PR TITLE
fix: correct banner source display and task ordering for GitHub mode

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -1081,11 +1081,11 @@ get_tasks_github() {
 }
 
 get_next_task_github() {
-  local args=(--repo "$GITHUB_REPO" --state open --limit 1 --json number,title)
+  local args=(--repo "$GITHUB_REPO" --state open --json number,title)
   [[ -n "$GITHUB_LABEL" ]] && args+=(--label "$GITHUB_LABEL")
 
   gh issue list "${args[@]}" \
-    --jq '.[0] | "\(.number):\(.title)"' 2>/dev/null | cut -c1-50 || echo ""
+    --jq 'sort_by(.number) | .[0] | "\(.number):\(.title)"' 2>/dev/null | cut -c1-50 || echo ""
 }
 
 count_remaining_github() {
@@ -2832,7 +2832,11 @@ main() {
     *) engine_display="${MAGENTA}Claude Code${RESET}" ;;
   esac
   echo "Engine: $engine_display"
-  echo "Source: ${CYAN}$PRD_SOURCE${RESET} (${PRD_FILE:-$GITHUB_REPO})"
+  if [[ "$PRD_SOURCE" == "github" ]]; then
+    echo "Source: ${CYAN}github${RESET} ($GITHUB_REPO)"
+  else
+    echo "Source: ${CYAN}$PRD_SOURCE${RESET} ($PRD_FILE)"
+  fi
   if [[ -d "$RALPHY_DIR" ]]; then
     echo "Config: ${GREEN}$RALPHY_DIR/${RESET} (rules loaded)"
   fi


### PR DESCRIPTION
## Summary

Fixes #8

This PR addresses two bugs when using `--github` mode:

1. **Banner source display**: The banner now correctly shows the repository name (e.g., `owner/repo`) instead of always showing `PRD.md`
2. **Task ordering**: GitHub issues are now processed in numerical order (lowest issue number first) instead of GitHub's default order (recently updated first)

## Changes

- **Banner fix** (line 2835): Added conditional check for `github` source to display `$GITHUB_REPO` directly instead of relying on the fallback which never triggered due to `$PRD_FILE` having a default value
- **Task ordering fix** (lines 1083-1088): Removed `--limit 1` and added `sort_by(.number)` in the jq expression to sort issues by number before selecting the first one

## Test plan

- [ ] Run `./ralphy.sh --github owner/repo` and verify banner shows `Source: github (owner/repo)`
- [ ] Create multiple numbered issues in a test repo and verify they are processed in order (issue #1 before #2, etc.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)