### PR TITLE
Add model examples to --model help text

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -696,6 +696,8 @@ ${BOLD}AI ENGINE OPTIONS:${RESET}
   --qwen              Use Qwen-Code
   --droid             Use Factory Droid
   --model <name>      Override default model for any engine
+                      Claude: sonnet, haiku, opus
+                      OpenCode: gpt-4o, gpt-4o-mini, o1, o3-mini
   --sonnet            Shortcut for --claude --model sonnet
 
 ${BOLD}WORKFLOW OPTIONS:${RESET}


### PR DESCRIPTION
Show available models for Claude (sonnet, haiku, opus) and OpenCode (gpt-4o, gpt-4o-mini, o1, o3-mini) in the help output.