### PR TITLE
docs: update README and bump version to 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ```
 
+### Model Override
+
+Override the default model for any engine:
+
+```bash
+ralphy --model sonnet "add feature"                    # use sonnet with Claude
+ralphy --sonnet "add feature"                          # shortcut for above
+ralphy --opencode --model opencode/glm-4.7-free "task" # custom OpenCode model
+ralphy --qwen --model qwen-max "build api"             # custom Qwen model
+```
+
 ## Task Sources
 
 **Markdown file** (default):
@@ -145,8 +156,9 @@ Agent 2 → /tmp/xxx/agent-2 → ralphy/agent-2-add-dashboard
 Agent 3 → /tmp/xxx/agent-3 → ralphy/agent-3-build-api
 ```
 
-Without `--create-pr`: auto-merges back, AI resolves conflicts.
+Without `--create-pr`: auto-merges back to base branch, AI resolves conflicts.
 With `--create-pr`: keeps branches, creates PRs.
+With `--no-merge`: keeps branches without merging or creating PRs.
 
 **YAML parallel groups** - control execution order:
 ```yaml
@@ -206,8 +218,11 @@ capabilities:
 | `--yaml FILE` | YAML task file |
 | `--github REPO` | use GitHub issues |
 | `--github-label TAG` | filter issues by label |
+| `--model NAME` | override model for any engine |
+| `--sonnet` | shortcut for `--claude --model sonnet` |
 | `--parallel` | run parallel |
 | `--max-parallel N` | max agents (default: 3) |
+| `--no-merge` | skip auto-merge in parallel mode |
 | `--branch-per-task` | branch per task |
 | `--base-branch NAME` | base branch |
 | `--create-pr` | create PRs |
@@ -258,6 +273,14 @@ capabilities:
 ---
 
 ## Changelog
+
+### v4.3.0
+- model override: `--model <name>` flag to override model for any engine
+- `--sonnet` shortcut for `--claude --model sonnet`
+- `--no-merge` flag to skip auto-merge in parallel mode
+- AI-assisted merge conflict resolution during parallel auto-merge
+- root user detection: error for Claude/Cursor, warning for other engines
+- improved OpenCode error handling and model override support
 
 ### v4.2.0
 - browser automation: `--browser` / `--no-browser` with [agent-browser](https://agent-browser.dev)

--- a/cli/README.md
+++ b/cli/README.md
@@ -75,6 +75,14 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ```
 
+### Model Override
+
+```bash
+ralphy --model sonnet "add feature"    # use sonnet with Claude
+ralphy --sonnet "add feature"          # shortcut for above
+ralphy --opencode --model opencode/glm-4.7-free "task"
+```
+
 ## Task Sources
 
 **Markdown file** (default):
@@ -106,7 +114,7 @@ ralphy --parallel                  # 3 agents default
 ralphy --parallel --max-parallel 5 # 5 agents
 ```
 
-Each agent gets isolated worktree + branch. Without `--create-pr`: auto-merges back. With `--create-pr`: keeps branches, creates PRs.
+Each agent gets isolated worktree + branch. Without `--create-pr`: auto-merges back with AI conflict resolution. With `--create-pr`: keeps branches, creates PRs. With `--no-merge`: keeps branches without merging.
 
 ## Branch Workflow
 
@@ -139,8 +147,11 @@ When enabled (and agent-browser is installed), the AI can:
 | `--yaml FILE` | YAML task file |
 | `--github REPO` | use GitHub issues |
 | `--github-label TAG` | filter issues by label |
+| `--model NAME` | override model for any engine |
+| `--sonnet` | shortcut for `--claude --model sonnet` |
 | `--parallel` | run parallel |
 | `--max-parallel N` | max agents (default: 3) |
+| `--no-merge` | skip auto-merge in parallel mode |
 | `--branch-per-task` | branch per task |
 | `--base-branch BRANCH` | base branch for PRs |
 | `--create-pr` | create PRs |

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ralphy-cli",
-	"version": "4.0.1",
+	"version": "4.3.0",
 	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code and Factory Droid",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
- Add model override documentation (--model, --sonnet flags)
- Document --no-merge flag for parallel execution
- Add AI-assisted merge conflict resolution to parallel docs
- Update options tables in both READMEs
- Add v4.3.0 changelog entry
- Bump version from 4.0.1 to 4.3.0