### PR TITLE
feat: add smart scheduling with LLM file prediction and DSatur algorithm

### DIFF
--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -36,6 +36,8 @@ export function createProgram(): Command {
     .option("--retry-delay <n>", "Delay between retries in seconds", "5")
     .option("--parallel", "Run tasks in parallel using worktrees")
     .option("--max-parallel <n>", "Maximum parallel agents", "3")
+    .option("--smart-schedule", "Use LLM to predict file conflicts and optimize task batching")
+    .option("--planning-model <name>", "Model to use for planning phase (cheaper model recommended)")
     .option("--branch-per-task", "Create a branch for each task")
     .option("--base-branch <branch>", "Base branch for PRs")
     .option("--create-pr", "Create pull request after each task")
@@ -142,6 +144,8 @@ export function parseArgs(args: string[]): {
           : "auto",
     modelOverride,
     skipMerge: opts.merge === false,
+    smartSchedule: opts.smartSchedule || false,
+    planningModel: opts.planningModel || undefined,
   };
 
   return {

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -117,6 +117,8 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 			prdFile: options.prdFile,
 			prdIsFolder: options.prdIsFolder,
 			activeSettings,
+			smartSchedule: options.smartSchedule,
+			planningModel: options.planningModel,
 		});
 	} else {
 		result = await runSequential({

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -91,6 +91,10 @@ export interface RuntimeOptions {
 	modelOverride?: string;
 	/** Skip automatic branch merging after parallel execution */
 	skipMerge?: boolean;
+	/** Use LLM to predict file conflicts and optimize task batching */
+	smartSchedule?: boolean;
+	/** Model to use for planning phase (cheaper model recommended) */
+	planningModel?: string;
 }
 
 /**

--- a/cli/src/execution/graph-coloring.ts
+++ b/cli/src/execution/graph-coloring.ts
@@ -1,0 +1,267 @@
+import type { Task } from "../tasks/types.ts";
+import { calculateFileOverlap, type TaskScope } from "./planning.ts";
+
+/**
+ * A node in the task dependency graph
+ */
+interface GraphNode {
+	task: Task;
+	scope: TaskScope;
+	color: number; // -1 means uncolored
+	adjacentColors: Set<number>; // Colors used by adjacent nodes
+	degree: number; // Number of edges
+}
+
+/**
+ * An edge in the task dependency graph (represents potential conflict)
+ */
+interface GraphEdge {
+	task1Id: string;
+	task2Id: string;
+	weight: number; // Overlap/conflict score
+}
+
+/**
+ * Task dependency graph for scheduling
+ */
+export interface TaskGraph {
+	nodes: Map<string, GraphNode>;
+	edges: GraphEdge[];
+}
+
+/**
+ * Build a task dependency graph based on file overlap.
+ * Tasks that modify the same files are connected with weighted edges.
+ */
+export function buildTaskGraph(
+	tasks: Task[],
+	scopes: Map<string, TaskScope>,
+	conflictThreshold = 1,
+): TaskGraph {
+	const nodes = new Map<string, GraphNode>();
+	const edges: GraphEdge[] = [];
+
+	// Create nodes
+	for (const task of tasks) {
+		const scope = scopes.get(task.id) || {
+			likelyFiles: [],
+			possibleFiles: [],
+			readOnlyDirs: [],
+		};
+
+		nodes.set(task.id, {
+			task,
+			scope,
+			color: -1,
+			adjacentColors: new Set(),
+			degree: 0,
+		});
+	}
+
+	// Create edges based on file overlap
+	for (let i = 0; i < tasks.length; i++) {
+		for (let j = i + 1; j < tasks.length; j++) {
+			const task1 = tasks[i];
+			const task2 = tasks[j];
+			const scope1 = scopes.get(task1.id);
+			const scope2 = scopes.get(task2.id);
+
+			if (scope1 && scope2) {
+				const overlap = calculateFileOverlap(scope1, scope2);
+
+				if (overlap >= conflictThreshold) {
+					edges.push({
+						task1Id: task1.id,
+						task2Id: task2.id,
+						weight: overlap,
+					});
+
+					// Update degrees
+					const node1 = nodes.get(task1.id);
+					const node2 = nodes.get(task2.id);
+					if (node1) node1.degree++;
+					if (node2) node2.degree++;
+				}
+			}
+		}
+	}
+
+	return { nodes, edges };
+}
+
+/**
+ * Calculate saturation degree for a node.
+ * Saturation = number of different colors used by adjacent nodes.
+ */
+function getSaturation(node: GraphNode): number {
+	return node.adjacentColors.size;
+}
+
+/**
+ * Find the uncolored node with highest saturation degree.
+ * Ties are broken by selecting the node with highest degree.
+ */
+function selectNextNode(nodes: Map<string, GraphNode>): GraphNode | null {
+	let bestNode: GraphNode | null = null;
+	let bestSaturation = -1;
+	let bestDegree = -1;
+
+	for (const node of nodes.values()) {
+		if (node.color !== -1) continue; // Already colored
+
+		const saturation = getSaturation(node);
+
+		if (
+			saturation > bestSaturation ||
+			(saturation === bestSaturation && node.degree > bestDegree)
+		) {
+			bestNode = node;
+			bestSaturation = saturation;
+			bestDegree = node.degree;
+		}
+	}
+
+	return bestNode;
+}
+
+/**
+ * Get the lowest available color for a node.
+ */
+function getLowestAvailableColor(node: GraphNode): number {
+	let color = 0;
+	while (node.adjacentColors.has(color)) {
+		color++;
+	}
+	return color;
+}
+
+/**
+ * Update adjacent colors after coloring a node.
+ */
+function updateAdjacentColors(
+	coloredNode: GraphNode,
+	graph: TaskGraph,
+): void {
+	for (const edge of graph.edges) {
+		let adjacentId: string | null = null;
+
+		if (edge.task1Id === coloredNode.task.id) {
+			adjacentId = edge.task2Id;
+		} else if (edge.task2Id === coloredNode.task.id) {
+			adjacentId = edge.task1Id;
+		}
+
+		if (adjacentId) {
+			const adjacentNode = graph.nodes.get(adjacentId);
+			if (adjacentNode && adjacentNode.color === -1) {
+				adjacentNode.adjacentColors.add(coloredNode.color);
+			}
+		}
+	}
+}
+
+/**
+ * Color the graph using DSatur algorithm.
+ * Returns the number of colors used (chromatic number approximation).
+ */
+export function colorGraph(graph: TaskGraph): number {
+	let maxColor = -1;
+
+	// Color nodes one by one
+	while (true) {
+		const node = selectNextNode(graph.nodes);
+		if (!node) break; // All nodes colored
+
+		const color = getLowestAvailableColor(node);
+		node.color = color;
+		maxColor = Math.max(maxColor, color);
+
+		updateAdjacentColors(node, graph);
+	}
+
+	return maxColor + 1; // Number of colors used
+}
+
+/**
+ * Group tasks by color (batch).
+ * Tasks with the same color can run in parallel without conflicts.
+ */
+export function groupTasksByColor(graph: TaskGraph): Task[][] {
+	const colorGroups = new Map<number, Task[]>();
+
+	for (const node of graph.nodes.values()) {
+		const group = colorGroups.get(node.color) || [];
+		group.push(node.task);
+		colorGroups.set(node.color, group);
+	}
+
+	// Sort by color (process lower colors first)
+	const sortedColors = Array.from(colorGroups.keys()).sort((a, b) => a - b);
+
+	return sortedColors.map((color) => colorGroups.get(color) || []);
+}
+
+/**
+ * Schedule tasks using DSatur graph coloring.
+ *
+ * This minimizes conflicts by:
+ * 1. Building a graph where edges represent potential conflicts (file overlap)
+ * 2. Coloring the graph so adjacent nodes have different colors
+ * 3. Grouping tasks by color - tasks with same color can run in parallel
+ *
+ * Returns batches of tasks that can be run in parallel without conflicts.
+ */
+export function scheduleTasksWithDSatur(
+	tasks: Task[],
+	scopes: Map<string, TaskScope>,
+	maxParallel: number,
+): Task[][] {
+	if (tasks.length === 0) return [];
+	if (tasks.length === 1) return [tasks];
+
+	// Build dependency graph
+	const graph = buildTaskGraph(tasks, scopes);
+
+	// Color the graph
+	const numColors = colorGraph(graph);
+
+	// Group by color
+	let batches = groupTasksByColor(graph);
+
+	// Further split batches if they exceed maxParallel
+	const finalBatches: Task[][] = [];
+	for (const batch of batches) {
+		if (batch.length <= maxParallel) {
+			finalBatches.push(batch);
+		} else {
+			// Split into smaller batches
+			for (let i = 0; i < batch.length; i += maxParallel) {
+				finalBatches.push(batch.slice(i, i + maxParallel));
+			}
+		}
+	}
+
+	return finalBatches;
+}
+
+/**
+ * Get scheduling statistics for logging.
+ */
+export function getSchedulingStats(
+	graph: TaskGraph,
+	batches: Task[][],
+): {
+	totalTasks: number;
+	totalBatches: number;
+	chromaticNumber: number;
+	maxBatchSize: number;
+	conflictEdges: number;
+} {
+	return {
+		totalTasks: graph.nodes.size,
+		totalBatches: batches.length,
+		chromaticNumber: new Set(Array.from(graph.nodes.values()).map((n) => n.color)).size,
+		maxBatchSize: Math.max(...batches.map((b) => b.length), 0),
+		conflictEdges: graph.edges.length,
+	};
+}

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -16,6 +16,8 @@ import { YamlTaskSource } from "../tasks/yaml.ts";
 import { logDebug, logError, logInfo, logSuccess, logWarn } from "../ui/logger.ts";
 import { notifyTaskComplete, notifyTaskFailed } from "../ui/notify.ts";
 import { resolveConflictsWithAI } from "./conflict-resolution.ts";
+import { scheduleTasksWithDSatur } from "./graph-coloring.ts";
+import { predictTaskScopes } from "./planning.ts";
 import { buildParallelPrompt } from "./prompt.ts";
 import { isRetryableError, sleep, withRetry } from "./retry.ts";
 import type { ExecutionOptions, ExecutionResult } from "./sequential.ts";
@@ -144,6 +146,8 @@ export async function runParallel(
 		browserEnabled,
 		modelOverride,
 		skipMerge,
+		smartSchedule = false,
+		planningModel,
 	} = options;
 
 	const result: ExecutionResult = {
@@ -157,6 +161,9 @@ export async function runParallel(
 	const worktreeBase = getWorktreeBase(workDir);
 	logDebug(`Worktree base: ${worktreeBase}`);
 
+	// Pre-computed batches for smart scheduling (if enabled)
+	let smartBatches: Task[][] | null = null;
+
 	// Save starting branch to restore after merge phase
 	const startingBranch = await getCurrentBranch(workDir);
 
@@ -169,8 +176,30 @@ export async function runParallel(
 	// Global agent counter to ensure unique numbering across batches
 	let globalAgentNum = 0;
 
+	// If smart scheduling is enabled, compute optimal batches upfront
+	if (smartSchedule && !dryRun) {
+		logInfo("Computing optimal task batches with LLM file prediction...");
+		const allTasks = await taskSource.getAllTasks();
+
+		if (allTasks.length > 1) {
+			// Predict which files each task will modify
+			const scopes = await predictTaskScopes(
+				allTasks,
+				engine,
+				workDir,
+				planningModel || modelOverride,
+			);
+
+			// Use DSatur algorithm to create conflict-minimizing batches
+			smartBatches = scheduleTasksWithDSatur(allTasks, scopes, maxParallel);
+
+			logInfo(`Smart scheduling: ${allTasks.length} tasks organized into ${smartBatches.length} conflict-minimizing batches`);
+		}
+	}
+
 	// Process tasks in batches
 	let iteration = 0;
+	let smartBatchIndex = 0;
 
 	while (true) {
 		// Check iteration limit
@@ -182,8 +211,16 @@ export async function runParallel(
 		// Get tasks for this batch
 		let tasks: Task[] = [];
 
-		// For YAML sources, try to get tasks from the same parallel group
-		if (taskSource instanceof YamlTaskSource) {
+		if (smartBatches && smartBatchIndex < smartBatches.length) {
+			// Use pre-computed smart batches
+			tasks = smartBatches[smartBatchIndex];
+			smartBatchIndex++;
+		} else if (smartBatches && smartBatchIndex >= smartBatches.length) {
+			// All smart batches processed
+			logSuccess("All tasks completed!");
+			break;
+		} else if (taskSource instanceof YamlTaskSource) {
+			// For YAML sources, try to get tasks from the same parallel group
 			const nextTask = await taskSource.getNextTask();
 			if (!nextTask) break;
 
@@ -203,8 +240,8 @@ export async function runParallel(
 			break;
 		}
 
-		// Limit to maxParallel
-		const batch = tasks.slice(0, maxParallel);
+		// Limit to maxParallel (unless using smart batches which are already sized)
+		const batch = smartBatches ? tasks : tasks.slice(0, maxParallel);
 		iteration++;
 
 		logInfo(`Batch ${iteration}: ${batch.length} tasks in parallel`);

--- a/cli/src/execution/planning.ts
+++ b/cli/src/execution/planning.ts
@@ -1,0 +1,224 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import type { AIEngine } from "../engines/types.ts";
+import type { Task } from "../tasks/types.ts";
+import { logDebug } from "../ui/logger.ts";
+
+/**
+ * Predicted scope of files a task will modify
+ */
+export interface TaskScope {
+	/** Files that will likely be modified */
+	likelyFiles: string[];
+	/** Files that might be modified */
+	possibleFiles: string[];
+	/** Read-only directories (dependencies) */
+	readOnlyDirs: string[];
+}
+
+/**
+ * Default read-only directories that are never modified by tasks
+ */
+const DEFAULT_READONLY_DIRS = [
+	"node_modules",
+	".git",
+	"vendor",
+	".venv",
+	"venv",
+	"__pycache__",
+	".pnpm-store",
+	".yarn",
+	"target",
+	"build",
+	"dist",
+	".next",
+	".nuxt",
+	".output",
+	".cache",
+];
+
+/**
+ * Get a simplified project structure for the LLM prompt.
+ * Excludes node_modules and other large directories.
+ */
+export function getProjectStructure(
+	workDir: string,
+	maxDepth = 3,
+	excludeDirs = DEFAULT_READONLY_DIRS,
+): string[] {
+	const files: string[] = [];
+
+	function scan(dir: string, depth: number) {
+		if (depth > maxDepth) return;
+
+		try {
+			const items = readdirSync(dir);
+
+			for (const item of items) {
+				// Skip hidden files and excluded directories
+				if (item.startsWith(".") && item !== ".ralphy") continue;
+				if (excludeDirs.includes(item)) continue;
+
+				const fullPath = join(dir, item);
+				const relPath = relative(workDir, fullPath);
+
+				try {
+					const stat = statSync(fullPath);
+
+					if (stat.isDirectory()) {
+						files.push(`${relPath}/`);
+						scan(fullPath, depth + 1);
+					} else if (stat.isFile()) {
+						files.push(relPath);
+					}
+				} catch {
+					// Skip files we can't stat
+				}
+			}
+		} catch {
+			// Skip directories we can't read
+		}
+	}
+
+	scan(workDir, 0);
+	return files.slice(0, 200); // Limit to 200 files to keep prompt manageable
+}
+
+/**
+ * Build a prompt for the LLM to predict file scope.
+ */
+function buildScopePredictionPrompt(task: Task, projectFiles: string[]): string {
+	return `Given this coding task and project structure, predict which files will be modified.
+
+## Task
+${task.title}
+${task.body ? `\nDetails: ${task.body}` : ""}
+
+## Project Files
+${projectFiles.join("\n")}
+
+## Instructions
+Analyze the task and predict:
+1. likelyFiles: Files that will definitely need to be modified
+2. possibleFiles: Files that might need to be modified
+3. readOnlyDirs: Directories that contain dependencies (node_modules, vendor, etc.)
+
+Respond with ONLY valid JSON in this exact format:
+{
+  "likelyFiles": ["src/file1.ts", "src/file2.ts"],
+  "possibleFiles": ["src/utils/helper.ts"],
+  "readOnlyDirs": ["node_modules", ".git"]
+}
+
+Keep predictions minimal - only include files directly related to the task.`;
+}
+
+/**
+ * Parse the LLM response to extract TaskScope.
+ */
+function parseScopeResponse(response: string): TaskScope | null {
+	try {
+		// Try to extract JSON from the response
+		const jsonMatch = response.match(/\{[\s\S]*\}/);
+		if (!jsonMatch) return null;
+
+		const parsed = JSON.parse(jsonMatch[0]);
+
+		return {
+			likelyFiles: Array.isArray(parsed.likelyFiles) ? parsed.likelyFiles : [],
+			possibleFiles: Array.isArray(parsed.possibleFiles) ? parsed.possibleFiles : [],
+			readOnlyDirs: Array.isArray(parsed.readOnlyDirs)
+				? parsed.readOnlyDirs
+				: DEFAULT_READONLY_DIRS,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Use LLM to predict which files a task will modify.
+ *
+ * This can be used to:
+ * 1. Create more targeted sandboxes (only copy likely modified files)
+ * 2. Detect potential conflicts between parallel tasks
+ * 3. Optimize batch scheduling
+ */
+export async function predictTaskScope(
+	task: Task,
+	engine: AIEngine,
+	workDir: string,
+	modelOverride?: string,
+): Promise<TaskScope> {
+	const projectFiles = getProjectStructure(workDir);
+	const prompt = buildScopePredictionPrompt(task, projectFiles);
+
+	try {
+		const engineOptions = modelOverride ? { modelOverride } : undefined;
+		const result = await engine.execute(prompt, workDir, engineOptions);
+
+		if (result.success && result.response) {
+			const scope = parseScopeResponse(result.response);
+			if (scope) {
+				logDebug(`Predicted scope for "${task.title}": ${scope.likelyFiles.length} likely, ${scope.possibleFiles.length} possible`);
+				return scope;
+			}
+		}
+	} catch (error) {
+		logDebug(`Failed to predict scope for "${task.title}": ${error}`);
+	}
+
+	// Return default scope if prediction fails
+	return {
+		likelyFiles: [],
+		possibleFiles: [],
+		readOnlyDirs: DEFAULT_READONLY_DIRS,
+	};
+}
+
+/**
+ * Predict scopes for multiple tasks in parallel.
+ */
+export async function predictTaskScopes(
+	tasks: Task[],
+	engine: AIEngine,
+	workDir: string,
+	modelOverride?: string,
+): Promise<Map<string, TaskScope>> {
+	const scopes = new Map<string, TaskScope>();
+
+	// Run predictions in parallel (they're independent)
+	const predictions = await Promise.all(
+		tasks.map(async (task) => {
+			const scope = await predictTaskScope(task, engine, workDir, modelOverride);
+			return { taskId: task.id, scope };
+		}),
+	);
+
+	for (const { taskId, scope } of predictions) {
+		scopes.set(taskId, scope);
+	}
+
+	return scopes;
+}
+
+/**
+ * Calculate file overlap between two task scopes.
+ * Higher overlap = higher conflict likelihood.
+ */
+export function calculateFileOverlap(scope1: TaskScope, scope2: TaskScope): number {
+	const files1 = new Set([...scope1.likelyFiles, ...scope1.possibleFiles]);
+	const files2 = new Set([...scope2.likelyFiles, ...scope2.possibleFiles]);
+
+	let overlap = 0;
+	for (const file of files1) {
+		if (files2.has(file)) {
+			// Weight likely files higher
+			const weight1 = scope1.likelyFiles.includes(file) ? 2 : 1;
+			const weight2 = scope2.likelyFiles.includes(file) ? 2 : 1;
+			overlap += weight1 + weight2;
+		}
+	}
+
+	return overlap;
+}

--- a/cli/src/execution/sequential.ts
+++ b/cli/src/execution/sequential.ts
@@ -31,6 +31,10 @@ export interface ExecutionOptions {
 	modelOverride?: string;
 	/** Skip automatic branch merging after parallel execution */
 	skipMerge?: boolean;
+	/** Use LLM to predict file conflicts and optimize task batching */
+	smartSchedule?: boolean;
+	/** Model to use for planning phase (cheaper model recommended) */
+	planningModel?: string;
 }
 
 export interface ExecutionResult {


### PR DESCRIPTION
Phase 4 introduces advanced task scheduling optimizations:

## New --smart-schedule flag

When using `ralphy --parallel --smart-schedule`, tasks are scheduled using:

1. **LLM File Prediction**: Before running tasks, asks the AI to predict which files each task will modify based on the task description and project structure.

2. **DSatur Graph Coloring**: Uses the Degree of Saturation algorithm to group tasks that don't share files. Tasks in the same group can run in parallel without merge conflicts.

## How it works

1. Get all remaining tasks
2. For each task, predict file scope (likelyFiles, possibleFiles)
3. Build a dependency graph where edges = potential conflicts (file overlap)
4. Color the graph using DSatur (adjacent nodes get different colors)
5. Group tasks by color - same color = can run in parallel safely

## New --planning-model flag

Use a cheaper model for the planning phase:
```bash
ralphy --parallel --smart-schedule --planning-model haiku
```

## Files added

- cli/src/execution/planning.ts - LLM file prediction
- cli/src/execution/graph-coloring.ts - DSatur algorithm

## Usage

```bash
# Basic smart scheduling
ralphy --parallel --smart-schedule

# With cheaper planning model
ralphy --parallel --smart-schedule --planning-model haiku
```

This is experimental - falls back to normal batching if prediction fails.