### PR TITLE
fix: handle null values in config and add sandbox docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,25 @@ Notifications include task completion counts and status (completed/failed).
 
 ## Sandbox Mode
 
-For large repos with big dependency directories, sandbox mode is faster than git worktrees.
-Uses symlinks for read-only dependencies (`node_modules`, `.git`, etc.) and copies source files.
+For large repos with big dependency directories, sandbox mode is faster than git worktrees:
 
-This is used internally during parallel execution when beneficial.
+```bash
+ralphy --parallel --sandbox
+```
+
+**How it works:**
+- **Symlinks** read-only dependencies (`node_modules`, `.git`, `vendor`, `.venv`, `.pnpm-store`, `.yarn`, `.cache`)
+- **Copies** source files that agents might modify (`src/`, `app/`, `lib/`, config files, etc.)
+
+**Why use it:**
+- Avoids duplicating gigabytes of `node_modules` across worktrees
+- Much faster sandbox creation for large monorepos
+- Changes sync back to original directory after each task
+
+**When to use worktrees instead (default):**
+- Need full git history access in each sandbox
+- Running `git` commands that require a real repo
+- Smaller repos where worktree overhead is minimal
 
 ## Options
 
@@ -263,6 +278,7 @@ This is used internally during parallel execution when beneficial.
 | `--sonnet` | shortcut for `--claude --model sonnet` |
 | `--parallel` | run parallel |
 | `--max-parallel N` | max agents (default: 3) |
+| `--sandbox` | use lightweight sandboxes instead of git worktrees |
 | `--no-merge` | skip auto-merge in parallel mode |
 | `--branch-per-task` | branch per task |
 | `--base-branch NAME` | base branch |

--- a/cli/README.md
+++ b/cli/README.md
@@ -126,6 +126,20 @@ ralphy --parallel --max-parallel 5 # 5 agents
 
 Each agent gets isolated worktree + branch. Without `--create-pr`: auto-merges back with AI conflict resolution. With `--create-pr`: keeps branches, creates PRs. With `--no-merge`: keeps branches without merging.
 
+### Sandbox Mode
+
+For large repos with big `node_modules` or dependency directories, use sandbox mode instead of git worktrees:
+
+```bash
+ralphy --parallel --sandbox
+```
+
+Sandboxes are faster because they:
+- **Symlink** read-only dependencies (`node_modules`, `.git`, `vendor`, `.venv`, etc.)
+- **Copy** only source files that agents might modify
+
+This avoids duplicating gigabytes of dependencies across worktrees. Changes are synced back to the original directory after each task completes.
+
 ## Branch Workflow
 
 ```bash
@@ -161,6 +175,7 @@ When enabled (and agent-browser is installed), the AI can:
 | `--sonnet` | shortcut for `--claude --model sonnet` |
 | `--parallel` | run parallel |
 | `--max-parallel N` | max agents (default: 3) |
+| `--sandbox` | use lightweight sandboxes instead of git worktrees |
 | `--no-merge` | skip auto-merge in parallel mode |
 | `--branch-per-task` | branch per task |
 | `--base-branch BRANCH` | base branch for PRs |

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ralphy-cli",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code, Factory Droid and GitHub Copilot",
 	"type": "module",
 	"main": "dist/index.js",

--- a/cli/src/config/loader.ts
+++ b/cli/src/config/loader.ts
@@ -50,7 +50,8 @@ export function loadConfig(workDir = process.cwd()): RalphyConfig | null {
 		const parsed = YAML.parse(content);
 		return RalphyConfigSchema.parse(parsed);
 	} catch (error) {
-		// Return default config if parsing fails
+		// Log error for debugging, but return default config
+		console.error(`Warning: Failed to parse config at ${configPath}:`, error);
 		return RalphyConfigSchema.parse({});
 	}
 }

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -32,7 +32,11 @@ export const CommandsSchema = z.object({
  * Boundaries schema
  */
 export const BoundariesSchema = z.object({
-	never_touch: z.array(z.string()).default([]),
+	never_touch: z
+		.array(z.string())
+		.nullable()
+		.transform((v) => v ?? [])
+		.default([]),
 });
 
 /**
@@ -41,7 +45,11 @@ export const BoundariesSchema = z.object({
 export const RalphyConfigSchema = z.object({
 	project: ProjectSchema.default({}),
 	commands: CommandsSchema.default({}),
-	rules: z.array(z.string()).default([]),
+	rules: z
+		.array(z.string())
+		.nullable()
+		.transform((v) => v ?? [])
+		.default([]),
 	boundaries: BoundariesSchema.default({}),
 	notifications: NotificationsSchema.default({}),
 });


### PR DESCRIPTION
## Summary

- **Fix config loading bug**: `ralphy --config` was showing "Unknown" for all values when config file contained null values (e.g., `never_touch: null`). The Zod schema now handles null gracefully by converting it to an empty array.
- **Add error logging**: Config parsing errors are now logged instead of silently failing, making debugging easier.
- **Expand sandbox documentation**: Added comprehensive usage examples and explanations for `--sandbox` flag in both READMEs.

## Test plan

- [ ] Run `ralphy --config` with a config file that has `never_touch: null` - should now display correct values
- [ ] Run `ralphy --config` with a valid config - should still work as expected
- [ ] Verify sandbox docs appear correctly in both READMEs