### PR TITLE
Fix infinite loop in --parallel --dry-run mode

### DIFF
--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -317,8 +317,7 @@ export async function runParallel(
 		if (isYamlSource) {
 			// In dry-run mode, find the first task not already processed
 			let nextTask = await taskSource.getNextTask();
-			while (nextTask && dryRun && dryRunProcessedIds.has(nextTask.id)) {
-				// Skip to find an unprocessed task
+			if (dryRun && nextTask && dryRunProcessedIds.has(nextTask.id)) {
 				const allTasks = await taskSource.getAllTasks();
 				nextTask = allTasks.find((t) => !dryRunProcessedIds.has(t.id)) || null;
 			}


### PR DESCRIPTION
## Summary

Fixes #92

In dry-run mode with `--parallel`, the loop skips batch execution but never marks tasks as complete. Since `getNextTask()` returns tasks based on the `completed` flag in the YAML file, it keeps returning the same tasks, causing an infinite loop.

## Solution

Track processed task IDs in memory during dry-run mode (since we don't want to modify the source file in a dry run):

1. Added `dryRunProcessedIds` Set to track which tasks have been processed
2. Filter out already-processed tasks when fetching the next batch
3. Add tasks to the Set after each batch is "skipped"

## Testing

Before fix:
```
[INFO] Batch 1: 3 tasks in parallel
[INFO] (dry run) Skipping batch
[INFO] Batch 2: 3 tasks in parallel
...
[INFO] Batch 239919: 3 tasks in parallel
(runs forever)
```

After fix:
```
[INFO] Batch 1: 3 tasks in parallel
[INFO] (dry run) Skipping batch
...
[INFO] Batch 9: 1 tasks in parallel
[INFO] (dry run) Skipping batch

==================================================
[INFO] Summary:
  Completed: 0
  Failed:    0
  Duration:  147ms
==================================================
```

Tested against a 21-task YAML file with parallel groups - correctly processes 9 batches and terminates.