### PR TITLE
Enhance --verbose logging with detailed agent reasoning

### DIFF
--- a/cli/src/engines/base.ts
+++ b/cli/src/engines/base.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
+import { logDebug } from "../ui/logger.ts";
 import type { AIEngine, AIResult, EngineOptions, ProgressCallback } from "./types.ts";
 
 // Check if running in Bun
@@ -264,6 +265,56 @@ export async function execCommandStreaming(
 			resolve({ exitCode: 1 });
 		});
 	});
+}
+
+/**
+ * Log detailed event information if in verbose mode
+ */
+export function logVerboseEvent(line: string): void {
+	// Fast path: skip non-JSON lines
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("{")) {
+		return;
+	}
+
+	try {
+		const parsed = JSON.parse(trimmed);
+
+		// 1. Log Chain of Thought
+		// OpenCode/Claude might use different fields for reasoning
+		const thought =
+			parsed.thought || parsed.reasoning || (parsed.type === "thought" ? parsed.content : null);
+		if (thought) {
+			logDebug(`Thinking: ${thought}`);
+			return;
+		}
+
+		// 2. Log Tool Calls
+		// Handle various formats (OpenCode, Claude, etc.)
+		if (parsed.type === "tool_use" || parsed.tool) {
+			const toolName = parsed.tool || parsed.name || parsed.tool_name;
+			const toolInput = parsed.input || parsed.arguments || parsed.args;
+
+			if (toolName) {
+				logDebug(`Tool Call: ${toolName}`);
+				if (toolInput) {
+					logDebug(
+						`   Input: ${typeof toolInput === "string" ? toolInput : JSON.stringify(toolInput)}`,
+					);
+				}
+			}
+			return;
+		}
+
+		// 3. Log Tool Results (optional)
+		if (parsed.type === "tool_result") {
+			logDebug(
+				`Tool Result: ${parsed.tool_name || parsed.name || "Unknown"} (Status: ${parsed.is_error ? "Error" : "Success"})`,
+			);
+		}
+	} catch {
+		// Ignore
+	}
 }
 
 /**

--- a/cli/src/engines/claude.ts
+++ b/cli/src/engines/claude.ts
@@ -4,6 +4,7 @@ import {
 	detectStepFromOutput,
 	execCommand,
 	execCommandStreaming,
+	logVerboseEvent,
 	parseStreamJsonResult,
 } from "./base.ts";
 import type { AIResult, EngineOptions, ProgressCallback } from "./types.ts";
@@ -37,15 +38,21 @@ export class ClaudeEngine extends BaseAIEngine {
 			args.push("-p", prompt);
 		}
 
-		const { stdout, stderr, exitCode } = await execCommand(
+		const outputLines: string[] = [];
+
+		const { exitCode } = await execCommandStreaming(
 			this.cliCommand,
 			args,
 			workDir,
+			(line) => {
+				outputLines.push(line);
+				logVerboseEvent(line);
+			},
 			undefined,
 			stdinContent,
 		);
 
-		const output = stdout + stderr;
+		const output = outputLines.join("\n");
 
 		// Check for errors
 		const error = checkForErrors(output);
@@ -114,6 +121,9 @@ export class ClaudeEngine extends BaseAIEngine {
 			workDir,
 			(line) => {
 				outputLines.push(line);
+
+				// Log detailed execution steps if verbose
+				logVerboseEvent(line);
 
 				// Detect and report step changes
 				const step = detectStepFromOutput(line);

--- a/cli/src/engines/opencode.ts
+++ b/cli/src/engines/opencode.ts
@@ -1,4 +1,10 @@
-import { BaseAIEngine, checkForErrors, execCommand } from "./base.ts";
+import {
+	BaseAIEngine,
+	checkForErrors,
+	execCommand,
+	execCommandStreaming,
+	logVerboseEvent,
+} from "./base.ts";
 import type { AIResult, EngineOptions } from "./types.ts";
 
 const isWindows = process.platform === "win32";
@@ -28,15 +34,21 @@ export class OpenCodeEngine extends BaseAIEngine {
 			args.push(prompt);
 		}
 
-		const { stdout, stderr, exitCode } = await execCommand(
+		const outputLines: string[] = [];
+
+		const { exitCode } = await execCommandStreaming(
 			this.cliCommand,
 			args,
 			workDir,
+			(line) => {
+				outputLines.push(line);
+				logVerboseEvent(line);
+			},
 			{ OPENCODE_PERMISSION: '{"*":"allow"}' },
 			stdinContent,
 		);
 
-		const output = stdout + stderr;
+		const output = outputLines.join("\n");
 
 		// Check for errors
 		const error = checkForErrors(output);


### PR DESCRIPTION
## Summary
This PR enhances the `--verbose` logging to provide a much more detailed output, specifically including full agent reasoning (Chain of Thought) and detailed execution steps for both OpenCode and Claude engines.

Key changes:
- Added `logVerboseEvent` in `base.ts` to parse and log JSON events (thoughts, tool calls).
- Updated `OpenCodeEngine` to use streaming execution internally to support real-time verbose logging.
- Updated `ClaudeEngine` to log verbose events during streaming and non-streaming execution.

Closes #101

## Verification
- Run `ralphy task "something" --verbose` with OpenCode or Claude engine.
- Verify that "Thinking:" and "Tool Call:" logs appear in the output.