### PR TITLE
chore: release v4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ ralphy --parallel --sandbox
 | `--yaml FILE` | YAML task file |
 | `--github REPO` | use GitHub issues |
 | `--github-label TAG` | filter issues by label |
+| `--sync-issue N` | sync PRD progress to GitHub issue #N |
 | `--model NAME` | override model for any engine |
 | `--sonnet` | shortcut for `--claude --model sonnet` |
 | `--parallel` | run parallel |
@@ -341,6 +342,12 @@ When an engine exits non-zero, ralphy includes the last lines of CLI output in t
 ---
 
 ## Changelog
+
+### v4.6.0
+- **Gemini CLI support**: new `--gemini` engine option for Google Gemini CLI
+- **GitHub issue sync**: `--sync-issue <number>` syncs PRD progress to a GitHub issue after each task
+- **performance improvements**: reduced redundant file reads, exponential backoff for retries, non-blocking logging, operation timing visibility
+- **version fix**: CLI version now reads dynamically from package.json
 
 ### v4.5.3
 - parallel reliability: fallback to sandbox mode on worktree errors

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ralphy-cli",
-	"version": "4.5.3",
-	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code, Factory Droid and GitHub Copilot",
+	"version": "4.6.0",
+	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code, Factory Droid, GitHub Copilot and Gemini CLI",
 	"type": "module",
 	"main": "dist/index.js",
 	"bin": {


### PR DESCRIPTION
## Summary
- Bump CLI version from 4.5.3 to 4.6.0
- Update README changelog with recent merged PRs
- Add `--sync-issue` to Options table

## Changes in v4.6.0 (from recent PRs)
- **Gemini CLI support** (#113): new `--gemini` engine option for Google Gemini CLI
- **GitHub issue sync** (#110): `--sync-issue <number>` syncs PRD progress to a GitHub issue after each task
- **Performance improvements** (#106): reduced redundant file reads, exponential backoff for retries, non-blocking logging, operation timing visibility
- **Version fix** (#105): CLI version now reads dynamically from package.json

## Test plan
- [ ] Verify `ralphy --version` shows 4.6.0
- [ ] Verify README changelog renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)