### PR TITLE
chore: bump version to 4.7.0 for JSON PRD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ When an engine exits non-zero, ralphy includes the last lines of CLI output in t
 
 ## Changelog
 
+### v4.7.0
+- **JSON PRD support**: new `--json` flag to use JSON files as task sources with support for parallel groups and task descriptions
+
 ### v4.6.0
 - **Gemini CLI support**: new `--gemini` engine option for Google Gemini CLI
 - **GitHub issue sync**: `--sync-issue <number>` syncs PRD progress to a GitHub issue after each task

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ralphy-cli",
-	"version": "4.6.0",
+	"version": "4.7.0",
 	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code, Factory Droid, GitHub Copilot and Gemini CLI",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version from 4.6.0 to 4.7.0
- Adds changelog entry for JSON PRD support feature (merged in PR #84)

## Test plan
- [ ] Verify version displays correctly with `ralphy --version`
- [ ] Confirm changelog renders properly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)