### PR TITLE
docs: update Copilot engine details and bump to v4.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ ralphy --parallel --sandbox
 | Cursor | `agent` | `--force` | duration |
 | Qwen | `qwen` | `--approval-mode yolo` | tokens |
 | Droid | `droid exec` | `--auto medium` | duration |
-| Copilot | `copilot` | `-p` flag | duration |
+| Copilot | `copilot` | `--yolo` | tokens |
 | Gemini | `gemini` | `--yolo` | tokens + cost |
 
 When an engine exits non-zero, ralphy includes the last lines of CLI output in the error message to make debugging easier.
@@ -361,6 +361,11 @@ When an engine exits non-zero, ralphy includes the last lines of CLI output in t
 ---
 
 ## Changelog
+
+### v4.7.1
+- **Copilot engine improvements**: non-interactive mode (`--yolo`), proper error detection for auth/rate-limit/network errors, token usage parsing, temp file-based prompts for markdown preservation
+- **Fixed infinite retry loop**: tasks now properly abort on fatal configuration/authentication errors
+- **Project standards**: added `.editorconfig` and `.gitattributes` for consistent coding styles
 
 ### v4.7.0
 - **JSON PRD support**: new `--json` flag to use JSON files as task sources with support for parallel groups and task descriptions

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ralphy-cli",
-	"version": "4.7.0",
+	"version": "4.7.1",
 	"description": "Autonomous AI Coding Loop - Supports Claude Code, OpenCode, Codex, Cursor, Qwen-Code, Factory Droid, GitHub Copilot and Gemini CLI",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Update Engine Details table in README: Copilot now uses `--yolo` flag for permissions and outputs tokens (instead of `-p` flag and duration)
- Add v4.7.1 changelog entry documenting PR #112 improvements
- Bump version to 4.7.1

## Changes
This PR updates the documentation to reflect the Copilot engine improvements from PR #112:
- Non-interactive mode (`--yolo`)
- Proper error detection for auth/rate-limit/network errors
- Token usage parsing
- Fixed infinite retry loop on fatal errors
- Project standards (.editorconfig, .gitattributes)

## Test plan
- [x] README changes are accurate
- [x] Version bump in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)