### PR TITLE
Adds the .github/skills folder for skills detection

### DIFF
--- a/cli/src/config/writer.ts
+++ b/cli/src/config/writer.ts
@@ -35,7 +35,7 @@ rules:
   # - "Use server actions instead of API routes in Next.js"
   #
   # Skills/playbooks (optional):
-  # - "Before coding, read and follow any relevant skill/playbook docs under .opencode/skills or .claude/skills."
+  # - "Before coding, read and follow any relevant skill/playbook docs under .opencode/skills, .claude/skills, or .github/skills."
 
 # Boundaries - files/folders the AI should not modify
 boundaries:

--- a/cli/src/execution/prompt.ts
+++ b/cli/src/execution/prompt.ts
@@ -22,6 +22,7 @@ function detectAgentSkills(workDir: string): string[] {
 	const candidates = [
 		join(workDir, ".opencode", "skills"),
 		join(workDir, ".claude", "skills"),
+		join(workDir, ".github", "skills"),
 		join(workDir, ".skills"),
 	];
 


### PR DESCRIPTION
This pull request updates the configuration and skill detection logic to recognize an additional skills directory, improving compatibility with more project setups.

**Configuration and skill detection improvements:**

* Updated the skill/playbook documentation guidance in `writer.ts` to include the `.github/skills` directory as a valid location for skill docs.
* Enhanced the `detectAgentSkills` function in `prompt.ts` to also check for skills in the `.github/skills` directory.