### PR TITLE
feature: implement chained integration branches for parallel groups

### DIFF
--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -620,7 +620,7 @@ export async function runParallel(
 		// If any retryable failure occurred, stop the run to allow retry later
 		// CHAINING LOGIC: Merge this batch's work into an integration branch
 		// Only do this if we have successful branches and we aren't stopping early
-		if (!skipMerge && !dryRun && !sawRetryableFailure && iteration > 0) {
+		if (!skipMerge && !dryRun && !sawRetryableFailure && completedBranches.length > 0) {
 			// We need to find which branches were successful in THIS batch
 			// refetching from the results array is safer
 			const currentBatchBranches = results
@@ -634,7 +634,8 @@ export async function runParallel(
 					const integrationBranch = await createIntegrationBranch(
 						iteration, 
 						currentBaseBranch, 
-						workDir
+						workDir,
+						originalBaseBranch // Use original base branch as prefix for namespacing
 					);
 					
 					logInfo(`Merging ${currentBatchBranches.length} branch(es) into ${integrationBranch}...`);
@@ -655,21 +656,18 @@ export async function runParallel(
 					currentBaseBranch = integrationBranch;
 					logSuccess(`Batch ${iteration} integrated into ${currentBaseBranch}`);
 					
-					// Remove the merged branches from completedBranches list so we don't try to merge them AGAIN at the end
-					// Actually, the structure of parallel.ts has a final merge phase.
-					// If we are chaining, the final merge phase should effectively merge the *last* integration branch.
-					// So strictly speaking, we should clear completedBranches or update the logic.
-					
-					// Better approach:
-					// If we successfully integrated, those branches are "done".
-					// We only need to track the *currentBaseBranch* as the thing to merge at the very end.
-					// However, the `completedBranches` array is used in the final block.
-					// Let's modify the final block logic instead.
-					
+					// Remove merged branches from completedBranches to avoid re-merging them at the end
+					for (const branch of currentBatchBranches) {
+						const idx = completedBranches.indexOf(branch);
+						if (idx !== -1) {
+							completedBranches.splice(idx, 1);
+						}
+					}					
 				} catch (err) {
 					logError(`Failed to create integration branch: ${err}`);
-					// Continue with current base branch? Or stop?
-					// Probably safer to stop or just warn.
+					logWarn("Integration failed, stopping execution to preserve dependency chain.");
+					// Stop execution because subsequent batches depend on this integration
+					break;
 				}
 			}
 		}
@@ -683,11 +681,14 @@ export async function runParallel(
 	// Merge phase: merge final integration branch back to base branch
 	// If we used integration branches, 'currentBaseBranch' holds the accumulated work.
 	// We need to merge 'currentBaseBranch' into 'originalBaseBranch'.
-	// If we DID NOT use integration branches (e.g. 1 batch or skipped), we fall back to standard merge.
+	// We ALSO need to merge any leftover branches in 'completedBranches' (e.g. if a batch failed to integrate).
 
-	const finalMergeBranch = currentBaseBranch !== originalBaseBranch ? [currentBaseBranch] : completedBranches;
+	const branchesToMerge = [...completedBranches];
+	if (currentBaseBranch !== originalBaseBranch) {
+		branchesToMerge.push(currentBaseBranch);
+	}
 	
-	if (!skipMerge && !dryRun && finalMergeBranch.length > 0) {
+	if (!skipMerge && !dryRun && branchesToMerge.length > 0) {
 		const git = simpleGit(workDir);
 		let stashed = false;
 		try {
@@ -704,30 +705,18 @@ export async function runParallel(
 
 		try {
 			if (currentBaseBranch !== originalBaseBranch) {
-				// We have a chain of integration branches. Merge the final one.
-				logInfo(`Merging final integration branch ${currentBaseBranch} into ${originalBaseBranch}`);
-				
-				// Use mergeAgentBranch for the single final merge
-				// Or use mergeCompletedBranches to get the nice conflict resolution logic for the final step too
-				await mergeCompletedBranches(
-					[currentBaseBranch],
-					originalBaseBranch,
-					engine,
-					workDir,
-					modelOverride,
-					engineArgs
-				);
-			} else {
-				// Standard merge of all individual branches (if no chaining happened)
-				await mergeCompletedBranches(
-					completedBranches,
-					originalBaseBranch,
-					engine,
-					workDir,
-					modelOverride,
-					engineArgs
-				);
+				// We have a chain of integration branches.
+				logInfo(`Merging final integration branch ${currentBaseBranch} and ${completedBranches.length} other(s) into ${originalBaseBranch}`);
 			}
+			
+			await mergeCompletedBranches(
+				branchesToMerge,
+				originalBaseBranch,
+				engine,
+				workDir,
+				modelOverride,
+				engineArgs
+			);
 
 			// Restore starting branch if we're not already on it
 			const currentBranch = await getCurrentBranch(workDir);

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -9,6 +9,7 @@ import { syncPrdToIssue } from "../git/issue-sync.ts";
 import {
 	abortMerge,
 	analyzePreMerge,
+	createIntegrationBranch,
 	deleteLocalBranch,
 	mergeAgentBranch,
 	sortByConflictLikelihood,
@@ -310,6 +311,9 @@ export async function runParallel(
 	// Track processed tasks in dry-run mode (since we don't modify the source file)
 	const dryRunProcessedIds = new Set<string>();
 
+	// Track the current base branch for chaining (integration branch pattern)
+	let currentBaseBranch = originalBaseBranch;
+
 	// Process tasks in batches
 	let iteration = 0;
 
@@ -409,7 +413,7 @@ export async function runParallel(
 				engine,
 				task,
 				globalAgentNum,
-				baseBranch,
+				currentBaseBranch,
 				isolationBase,
 				workDir,
 				prdSource,
@@ -466,11 +470,14 @@ export async function runParallel(
 							worktreeDir,
 							task.title,
 							agentNum,
-							originalBaseBranch,
+							currentBaseBranch,
 						);
 
 						if (commitResult.success) {
+							// Update branches map or result to ensure we track the generated branch
 							branchName = commitResult.branchName;
+							// Update the agentResult in place so we can find it later
+							agentResult.branchName = branchName;
 							logDebug(
 								`Agent ${agentNum}: Committed ${commitResult.filesCommitted} files to ${branchName}`,
 							);
@@ -611,14 +618,76 @@ export async function runParallel(
 		const batchDuration = formatDuration(Date.now() - batchStartTime);
 		logInfo(`Batch ${iteration} completed in ${batchDuration}`);
 		// If any retryable failure occurred, stop the run to allow retry later
+		// CHAINING LOGIC: Merge this batch's work into an integration branch
+		// Only do this if we have successful branches and we aren't stopping early
+		if (!skipMerge && !dryRun && !sawRetryableFailure && iteration > 0) {
+			// We need to find which branches were successful in THIS batch
+			// refetching from the results array is safer
+			const currentBatchBranches = results
+				.map(r => r.branchName) // This might be empty if failed
+				.filter(b => b && completedBranches.includes(b));
+				
+			if (currentBatchBranches.length > 0) {
+				try {
+					logInfo(`Creating integration branch for batch ${iteration}...`);
+					// Create integration branch from current base
+					const integrationBranch = await createIntegrationBranch(
+						iteration, 
+						currentBaseBranch, 
+						workDir
+					);
+					
+					logInfo(`Merging ${currentBatchBranches.length} branch(es) into ${integrationBranch}...`);
+					
+					// Merge the batch's branches into the integration branch
+					// We use a cleaner merge function or the existing mergeCompletedBranches logic?
+					// Use mergeCompletedBranches but pointed at the integration branch
+					await mergeCompletedBranches(
+						currentBatchBranches,
+						integrationBranch,
+						engine,
+						workDir,
+						modelOverride,
+						engineArgs
+					);
+					
+					// Update current base branch for the next batch
+					currentBaseBranch = integrationBranch;
+					logSuccess(`Batch ${iteration} integrated into ${currentBaseBranch}`);
+					
+					// Remove the merged branches from completedBranches list so we don't try to merge them AGAIN at the end
+					// Actually, the structure of parallel.ts has a final merge phase.
+					// If we are chaining, the final merge phase should effectively merge the *last* integration branch.
+					// So strictly speaking, we should clear completedBranches or update the logic.
+					
+					// Better approach:
+					// If we successfully integrated, those branches are "done".
+					// We only need to track the *currentBaseBranch* as the thing to merge at the very end.
+					// However, the `completedBranches` array is used in the final block.
+					// Let's modify the final block logic instead.
+					
+				} catch (err) {
+					logError(`Failed to create integration branch: ${err}`);
+					// Continue with current base branch? Or stop?
+					// Probably safer to stop or just warn.
+				}
+			}
+		}
+
 		if (sawRetryableFailure) {
 			logWarn("Stopping early due to retryable errors. Try again later.");
 			break;
 		}
 	}
 
-	// Merge phase: merge completed branches back to base branch
-	if (!skipMerge && !dryRun && completedBranches.length > 0) {
+	// Merge phase: merge final integration branch back to base branch
+	// If we used integration branches, 'currentBaseBranch' holds the accumulated work.
+	// We need to merge 'currentBaseBranch' into 'originalBaseBranch'.
+	// If we DID NOT use integration branches (e.g. 1 batch or skipped), we fall back to standard merge.
+
+	const finalMergeBranch = currentBaseBranch !== originalBaseBranch ? [currentBaseBranch] : completedBranches;
+	
+	if (!skipMerge && !dryRun && finalMergeBranch.length > 0) {
 		const git = simpleGit(workDir);
 		let stashed = false;
 		try {
@@ -634,14 +703,31 @@ export async function runParallel(
 		}
 
 		try {
-			await mergeCompletedBranches(
-				completedBranches,
-				originalBaseBranch,
-				engine,
-				workDir,
-				modelOverride,
-				engineArgs,
-			);
+			if (currentBaseBranch !== originalBaseBranch) {
+				// We have a chain of integration branches. Merge the final one.
+				logInfo(`Merging final integration branch ${currentBaseBranch} into ${originalBaseBranch}`);
+				
+				// Use mergeAgentBranch for the single final merge
+				// Or use mergeCompletedBranches to get the nice conflict resolution logic for the final step too
+				await mergeCompletedBranches(
+					[currentBaseBranch],
+					originalBaseBranch,
+					engine,
+					workDir,
+					modelOverride,
+					engineArgs
+				);
+			} else {
+				// Standard merge of all individual branches (if no chaining happened)
+				await mergeCompletedBranches(
+					completedBranches,
+					originalBaseBranch,
+					engine,
+					workDir,
+					modelOverride,
+					engineArgs
+				);
+			}
 
 			// Restore starting branch if we're not already on it
 			const currentBranch = await getCurrentBranch(workDir);

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -314,84 +314,111 @@ export async function runParallel(
 	// Track the current base branch for chaining (integration branch pattern)
 	let currentBaseBranch = originalBaseBranch;
 
-	// Process tasks in batches
-	let iteration = 0;
+	// Track created integration branches for cleanup
+	const createdIntegrationBranches: string[] = [];
 
-	while (true) {
-		// Check iteration limit
-		if (maxIterations > 0 && iteration >= maxIterations) {
-			logInfo(`Reached max iterations (${maxIterations})`);
-			break;
-		}
+	try {
+		// Process tasks in batches
+		let iteration = 0;
 
-		// Get tasks for this batch
-		let tasks: Task[] = [];
-
-		const taskSourceWithGroups = taskSource as TaskSource & {
-			getParallelGroup?: (title: string) => Promise<number>;
-			getTasksInGroup?: (group: number) => Promise<Task[]>;
-		};
-
-		if (taskSourceWithGroups.getParallelGroup && taskSourceWithGroups.getTasksInGroup) {
-			let nextTask = await taskSource.getNextTask();
-			if (dryRun && nextTask && dryRunProcessedIds.has(nextTask.id)) {
-				const allTasks = await taskSource.getAllTasks();
-				nextTask = allTasks.find((task) => !dryRunProcessedIds.has(task.id)) || null;
+		while (true) {
+			// Check iteration limit
+			if (maxIterations > 0 && iteration >= maxIterations) {
+				logInfo(`Reached max iterations (${maxIterations})`);
+				break;
 			}
-			if (!nextTask) break;
 
-			const group = await taskSourceWithGroups.getParallelGroup(nextTask.title);
-			if (group > 0) {
-				tasks = await taskSourceWithGroups.getTasksInGroup(group);
+			// Get tasks for this batch
+			let tasks: Task[] = [];
+
+			const taskSourceWithGroups = taskSource as TaskSource & {
+				getParallelGroup?: (title: string) => Promise<number>;
+				getTasksInGroup?: (group: number) => Promise<Task[]>;
+			};
+
+			if (taskSourceWithGroups.getParallelGroup && taskSourceWithGroups.getTasksInGroup) {
+				let nextTask = await taskSource.getNextTask();
+				if (dryRun && nextTask && dryRunProcessedIds.has(nextTask.id)) {
+					const allTasks = await taskSource.getAllTasks();
+					nextTask = allTasks.find((task) => !dryRunProcessedIds.has(task.id)) || null;
+				}
+				if (!nextTask) break;
+
+				const group = await taskSourceWithGroups.getParallelGroup(nextTask.title);
+				if (group > 0) {
+					tasks = await taskSourceWithGroups.getTasksInGroup(group);
+					if (dryRun) {
+						tasks = tasks.filter((task) => !dryRunProcessedIds.has(task.id));
+					}
+				} else {
+					tasks = [nextTask];
+				}
+			} else {
+				tasks = await taskSource.getAllTasks();
 				if (dryRun) {
 					tasks = tasks.filter((task) => !dryRunProcessedIds.has(task.id));
 				}
-			} else {
-				tasks = [nextTask];
 			}
-		} else {
-			tasks = await taskSource.getAllTasks();
+
+			if (tasks.length === 0) {
+				logSuccess("All tasks completed!");
+				break;
+			}
+
+			// Limit to maxParallel
+			const batch = tasks.slice(0, maxParallel);
+			iteration++;
+
+			const batchStartTime = Date.now();
+			logInfo(`Batch ${iteration}: ${batch.length} tasks in parallel`);
+
 			if (dryRun) {
-				tasks = tasks.filter((task) => !dryRunProcessedIds.has(task.id));
+				logInfo("(dry run) Skipping batch");
+				// Track processed tasks to avoid infinite loop
+				for (const task of batch) {
+					dryRunProcessedIds.add(task.id);
+				}
+				continue;
 			}
-		}
 
-		if (tasks.length === 0) {
-			logSuccess("All tasks completed!");
-			break;
-		}
-
-		// Limit to maxParallel
-		const batch = tasks.slice(0, maxParallel);
-		iteration++;
-
-		const batchStartTime = Date.now();
-		logInfo(`Batch ${iteration}: ${batch.length} tasks in parallel`);
-
-		if (dryRun) {
-			logInfo("(dry run) Skipping batch");
-			// Track processed tasks to avoid infinite loop
+			// Log task names being processed
 			for (const task of batch) {
-				dryRunProcessedIds.add(task.id);
+				logInfo(`  -> ${task.title}`);
 			}
-			continue;
-		}
 
-		// Log task names being processed
-		for (const task of batch) {
-			logInfo(`  -> ${task.title}`);
-		}
+			// Run agents in parallel (using sandbox or worktree mode)
+			const promises = batch.map((task) => {
+				globalAgentNum++;
 
-		// Run agents in parallel (using sandbox or worktree mode)
-		const promises = batch.map((task) => {
-			globalAgentNum++;
+				const runInSandbox = () =>
+					runAgentInSandbox(
+						engine,
+						task,
+						globalAgentNum,
+						getSandboxBase(workDir),
+						workDir,
+						prdSource,
+						prdFile,
+						prdIsFolder,
+						maxRetries,
+						retryDelay,
+						skipTests,
+						skipLint,
+						browserEnabled,
+						modelOverride,
+						engineArgs,
+					);
 
-			const runInSandbox = () =>
-				runAgentInSandbox(
+				if (effectiveUseSandbox) {
+					return runInSandbox();
+				}
+
+				return runAgentInWorktree(
 					engine,
 					task,
 					globalAgentNum,
-					getSandboxBase(workDir),
+					currentBaseBranch,
+					isolationBase,
 					workDir,
 					prdSource,
 					prdFile,
@@ -403,340 +430,356 @@ export async function runParallel(
 					browserEnabled,
 					modelOverride,
 					engineArgs,
-				);
-
-			if (effectiveUseSandbox) {
-				return runInSandbox();
-			}
-
-			return runAgentInWorktree(
-				engine,
-				task,
-				globalAgentNum,
-				currentBaseBranch,
-				isolationBase,
-				workDir,
-				prdSource,
-				prdFile,
-				prdIsFolder,
-				maxRetries,
-				retryDelay,
-				skipTests,
-				skipLint,
-				browserEnabled,
-				modelOverride,
-				engineArgs,
-			).then((res) => {
-				if (shouldFallbackToSandbox(res.error)) {
-					logWarn(`Agent ${globalAgentNum}: Worktree unavailable, retrying in sandbox mode.`);
-					if (res.worktreeDir) {
-						cleanupAgentWorktree(res.worktreeDir, res.branchName, workDir).catch(() => {
-							// Ignore cleanup failures during fallback
-						});
-					}
-					return runInSandbox();
-				}
-				return res;
-			});
-		});
-
-		const results = await Promise.all(promises);
-
-		// Process results and collect worktrees for parallel cleanup
-		let sawRetryableFailure = false;
-		const worktreesToCleanup: Array<{ worktreeDir: string; branchName: string }> = [];
-
-		for (const agentResult of results) {
-			const {
-				task,
-				agentNum,
-				worktreeDir,
-				result: aiResult,
-				error,
-				usedSandbox: agentUsedSandbox,
-			} = agentResult;
-			let branchName = agentResult.branchName;
-			let failureReason: string | undefined = error;
-			let retryableFailure = false;
-			let preserveSandbox = false;
-
-			if (!failureReason && aiResult?.success && agentUsedSandbox && worktreeDir) {
-				try {
-					const modifiedFiles = await getModifiedFiles(worktreeDir, workDir);
-					if (modifiedFiles.length > 0) {
-						const commitResult = await commitSandboxChanges(
-							workDir,
-							modifiedFiles,
-							worktreeDir,
-							task.title,
-							agentNum,
-							currentBaseBranch,
-						);
-
-						if (commitResult.success) {
-							// Update branches map or result to ensure we track the generated branch
-							branchName = commitResult.branchName;
-							// Update the agentResult in place so we can find it later
-							agentResult.branchName = branchName;
-							logDebug(
-								`Agent ${agentNum}: Committed ${commitResult.filesCommitted} files to ${branchName}`,
-							);
-						} else {
-							failureReason = commitResult.error || "Failed to commit sandbox changes";
-							preserveSandbox = true; // Preserve work for manual recovery
+				).then((res) => {
+					if (shouldFallbackToSandbox(res.error)) {
+						logWarn(`Agent ${globalAgentNum}: Worktree unavailable, retrying in sandbox mode.`);
+						if (res.worktreeDir) {
+							cleanupAgentWorktree(res.worktreeDir, res.branchName, workDir).catch(() => {
+								// Ignore cleanup failures during fallback
+							});
 						}
+						return runInSandbox();
 					}
-				} catch (commitErr) {
-					failureReason = commitErr instanceof Error ? commitErr.message : String(commitErr);
-					preserveSandbox = true; // Preserve work for manual recovery
-				}
-			}
+					return res;
+				});
+			});
 
-			if (failureReason) {
-				retryableFailure = isRetryableError(failureReason);
-				if (retryableFailure) {
-					const deferrals = recordDeferredTask(taskSource.type, task, workDir, prdFile);
-					if (deferrals >= maxRetries) {
-						logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${failureReason}`);
+			const results = await Promise.all(promises);
+
+			// Process results and collect worktrees for parallel cleanup
+			let sawRetryableFailure = false;
+			const worktreesToCleanup: Array<{ worktreeDir: string; branchName: string }> = [];
+
+			for (const agentResult of results) {
+				const {
+					task,
+					agentNum,
+					worktreeDir,
+					result: aiResult,
+					error,
+					usedSandbox: agentUsedSandbox,
+				} = agentResult;
+				let branchName = agentResult.branchName;
+				let failureReason: string | undefined = error;
+				let retryableFailure = false;
+				let preserveSandbox = false;
+
+				if (!failureReason && aiResult?.success && agentUsedSandbox && worktreeDir) {
+					try {
+						const modifiedFiles = await getModifiedFiles(worktreeDir, workDir);
+						if (modifiedFiles.length > 0) {
+							const commitResult = await commitSandboxChanges(
+								workDir,
+								modifiedFiles,
+								worktreeDir,
+								task.title,
+								agentNum,
+								currentBaseBranch,
+							);
+
+							if (commitResult.success) {
+								// Update branches map or result to ensure we track the generated branch
+								branchName = commitResult.branchName;
+								// Update the agentResult in place so we can find it later
+								agentResult.branchName = branchName;
+								logDebug(
+									`Agent ${agentNum}: Committed ${commitResult.filesCommitted} files to ${branchName}`,
+								);
+							} else {
+								failureReason = commitResult.error || "Failed to commit sandbox changes";
+								preserveSandbox = true; // Preserve work for manual recovery
+							}
+						}
+					} catch (commitErr) {
+						failureReason = commitErr instanceof Error ? commitErr.message : String(commitErr);
+						preserveSandbox = true; // Preserve work for manual recovery
+					}
+				}
+
+				if (failureReason) {
+					retryableFailure = isRetryableError(failureReason);
+					if (retryableFailure) {
+						const deferrals = recordDeferredTask(taskSource.type, task, workDir, prdFile);
+						if (deferrals >= maxRetries) {
+							logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${failureReason}`);
+							logTaskProgress(task.title, "failed", workDir);
+							result.tasksFailed++;
+							notifyTaskFailed(task.title, failureReason);
+							await taskSource.markComplete(task.id);
+							clearDeferredTask(taskSource.type, task, workDir, prdFile);
+							retryableFailure = false;
+						} else {
+							logWarn(`Task "${task.title}" deferred (${deferrals}/${maxRetries}): ${failureReason}`);
+							result.tasksFailed++;
+						}
+					} else {
+						logError(`Task "${task.title}" failed: ${failureReason}`);
 						logTaskProgress(task.title, "failed", workDir);
 						result.tasksFailed++;
 						notifyTaskFailed(task.title, failureReason);
+
+						// Mark failed task as complete to remove it from the queue
+						// This prevents infinite retry loops - the task has already been retried maxRetries times
 						await taskSource.markComplete(task.id);
 						clearDeferredTask(taskSource.type, task, workDir, prdFile);
-						retryableFailure = false;
-					} else {
-						logWarn(`Task "${task.title}" deferred (${deferrals}/${maxRetries}): ${failureReason}`);
-						result.tasksFailed++;
+					}
+				} else if (aiResult?.success) {
+					logSuccess(`Task "${task.title}" completed`);
+					result.totalInputTokens += aiResult.inputTokens;
+					result.totalOutputTokens += aiResult.outputTokens;
+
+					await taskSource.markComplete(task.id);
+					logTaskProgress(task.title, "completed", workDir);
+					result.tasksCompleted++;
+
+					notifyTaskComplete(task.title);
+					clearDeferredTask(taskSource.type, task, workDir, prdFile);
+
+					// Track successful branch for merge phase
+					if (branchName) {
+						completedBranches.push(branchName);
 					}
 				} else {
-					logError(`Task "${task.title}" failed: ${failureReason}`);
-					logTaskProgress(task.title, "failed", workDir);
-					result.tasksFailed++;
-					notifyTaskFailed(task.title, failureReason);
-
-					// Mark failed task as complete to remove it from the queue
-					// This prevents infinite retry loops - the task has already been retried maxRetries times
-					await taskSource.markComplete(task.id);
-					clearDeferredTask(taskSource.type, task, workDir, prdFile);
-				}
-			} else if (aiResult?.success) {
-				logSuccess(`Task "${task.title}" completed`);
-				result.totalInputTokens += aiResult.inputTokens;
-				result.totalOutputTokens += aiResult.outputTokens;
-
-				await taskSource.markComplete(task.id);
-				logTaskProgress(task.title, "completed", workDir);
-				result.tasksCompleted++;
-
-				notifyTaskComplete(task.title);
-				clearDeferredTask(taskSource.type, task, workDir, prdFile);
-
-				// Track successful branch for merge phase
-				if (branchName) {
-					completedBranches.push(branchName);
-				}
-			} else {
-				const errMsg = aiResult?.error || "Unknown error";
-				retryableFailure = isRetryableError(errMsg);
-				if (retryableFailure) {
-					const deferrals = recordDeferredTask(taskSource.type, task, workDir, prdFile);
-					if (deferrals >= maxRetries) {
-						logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${errMsg}`);
+					const errMsg = aiResult?.error || "Unknown error";
+					retryableFailure = isRetryableError(errMsg);
+					if (retryableFailure) {
+						const deferrals = recordDeferredTask(taskSource.type, task, workDir, prdFile);
+						if (deferrals >= maxRetries) {
+							logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${errMsg}`);
+							logTaskProgress(task.title, "failed", workDir);
+							result.tasksFailed++;
+							notifyTaskFailed(task.title, errMsg);
+							failureReason = errMsg;
+							await taskSource.markComplete(task.id);
+							clearDeferredTask(taskSource.type, task, workDir, prdFile);
+							retryableFailure = false;
+						} else {
+							logWarn(`Task "${task.title}" deferred (${deferrals}/${maxRetries}): ${errMsg}`);
+							result.tasksFailed++;
+							failureReason = errMsg;
+						}
+					} else {
+						logError(`Task "${task.title}" failed: ${errMsg}`);
 						logTaskProgress(task.title, "failed", workDir);
 						result.tasksFailed++;
 						notifyTaskFailed(task.title, errMsg);
 						failureReason = errMsg;
+
+						// Mark failed task as complete to remove it from the queue
+						// This prevents infinite retry loops - the task has already been retried maxRetries times
 						await taskSource.markComplete(task.id);
 						clearDeferredTask(taskSource.type, task, workDir, prdFile);
-						retryableFailure = false;
-					} else {
-						logWarn(`Task "${task.title}" deferred (${deferrals}/${maxRetries}): ${errMsg}`);
-						result.tasksFailed++;
-						failureReason = errMsg;
 					}
-				} else {
-					logError(`Task "${task.title}" failed: ${errMsg}`);
-					logTaskProgress(task.title, "failed", workDir);
-					result.tasksFailed++;
-					notifyTaskFailed(task.title, errMsg);
-					failureReason = errMsg;
-
-					// Mark failed task as complete to remove it from the queue
-					// This prevents infinite retry loops - the task has already been retried maxRetries times
-					await taskSource.markComplete(task.id);
-					clearDeferredTask(taskSource.type, task, workDir, prdFile);
 				}
-			}
 
-			// Cleanup sandbox inline or collect worktree for parallel cleanup
-			if (worktreeDir) {
-				if (agentUsedSandbox) {
-					if (failureReason || preserveSandbox) {
-						logWarn(`Sandbox preserved for manual review: ${worktreeDir}`);
-					} else {
-						// Sandbox cleanup is simpler - just delete the directory
-						await cleanupSandbox(worktreeDir);
-						logDebug(`Cleaned up sandbox: ${worktreeDir}`);
-					}
-				} else {
-					// Collect worktree for parallel cleanup below
-					worktreesToCleanup.push({ worktreeDir, branchName });
-				}
-			}
-
-			if (retryableFailure) {
-				sawRetryableFailure = true;
-			}
-		}
-
-		// Cleanup all worktrees in parallel
-		if (worktreesToCleanup.length > 0) {
-			const cleanupResults = await Promise.all(
-				worktreesToCleanup.map(({ worktreeDir, branchName }) =>
-					cleanupAgentWorktree(worktreeDir, branchName, workDir).then((cleanup) => ({
-						worktreeDir,
-						leftInPlace: cleanup.leftInPlace,
-					})),
-				),
-			);
-
-			// Log any worktrees left in place
-			for (const { worktreeDir, leftInPlace } of cleanupResults) {
-				if (leftInPlace) {
-					logInfo(`Worktree left in place (uncommitted changes): ${worktreeDir}`);
-				}
-			}
-		}
-
-		// Sync PRD to GitHub issue once per batch (after all tasks processed)
-		// This prevents multiple concurrent syncs and reduces API calls
-		if (syncIssue && prdFile && result.tasksCompleted > 0) {
-			await syncPrdToIssue(prdFile, syncIssue, workDir);
-		}
-
-		// Log batch completion time
-		const batchDuration = formatDuration(Date.now() - batchStartTime);
-		logInfo(`Batch ${iteration} completed in ${batchDuration}`);
-		// If any retryable failure occurred, stop the run to allow retry later
-		// CHAINING LOGIC: Merge this batch's work into an integration branch
-		// Only do this if we have successful branches and we aren't stopping early
-		if (!skipMerge && !dryRun && !sawRetryableFailure && completedBranches.length > 0) {
-			// We need to find which branches were successful in THIS batch
-			// refetching from the results array is safer
-			const currentBatchBranches = results
-				.map(r => r.branchName) // This might be empty if failed
-				.filter(b => b && completedBranches.includes(b));
-				
-			if (currentBatchBranches.length > 0) {
-				try {
-					logInfo(`Creating integration branch for batch ${iteration}...`);
-					// Create integration branch from current base
-					const integrationBranch = await createIntegrationBranch(
-						iteration, 
-						currentBaseBranch, 
-						workDir,
-						originalBaseBranch // Use original base branch as prefix for namespacing
-					);
-					
-					logInfo(`Merging ${currentBatchBranches.length} branch(es) into ${integrationBranch}...`);
-					
-					// Merge the batch's branches into the integration branch
-					// We use a cleaner merge function or the existing mergeCompletedBranches logic?
-					// Use mergeCompletedBranches but pointed at the integration branch
-					await mergeCompletedBranches(
-						currentBatchBranches,
-						integrationBranch,
-						engine,
-						workDir,
-						modelOverride,
-						engineArgs
-					);
-					
-					// Update current base branch for the next batch
-					currentBaseBranch = integrationBranch;
-					logSuccess(`Batch ${iteration} integrated into ${currentBaseBranch}`);
-					
-					// Remove merged branches from completedBranches to avoid re-merging them at the end
-					for (const branch of currentBatchBranches) {
-						const idx = completedBranches.indexOf(branch);
-						if (idx !== -1) {
-							completedBranches.splice(idx, 1);
+				// Cleanup sandbox inline or collect worktree for parallel cleanup
+				if (worktreeDir) {
+					if (agentUsedSandbox) {
+						if (failureReason || preserveSandbox) {
+							logWarn(`Sandbox preserved for manual review: ${worktreeDir}`);
+						} else {
+							// Sandbox cleanup is simpler - just delete the directory
+							await cleanupSandbox(worktreeDir);
+							logDebug(`Cleaned up sandbox: ${worktreeDir}`);
 						}
-					}					
-				} catch (err) {
-					logError(`Failed to create integration branch: ${err}`);
-					logWarn("Integration failed, stopping execution to preserve dependency chain.");
-					// Stop execution because subsequent batches depend on this integration
-					break;
+					} else {
+						// Collect worktree for parallel cleanup below
+						worktreesToCleanup.push({ worktreeDir, branchName });
+					}
+				}
+
+				if (retryableFailure) {
+					sawRetryableFailure = true;
+				}
+			}
+
+			// Cleanup all worktrees in parallel
+			if (worktreesToCleanup.length > 0) {
+				const cleanupResults = await Promise.all(
+					worktreesToCleanup.map(({ worktreeDir, branchName }) =>
+						cleanupAgentWorktree(worktreeDir, branchName, workDir).then((cleanup) => ({
+							worktreeDir,
+							leftInPlace: cleanup.leftInPlace,
+						})),
+					),
+				);
+
+				// Log any worktrees left in place
+				for (const { worktreeDir, leftInPlace } of cleanupResults) {
+					if (leftInPlace) {
+						logInfo(`Worktree left in place (uncommitted changes): ${worktreeDir}`);
+					}
+				}
+			}
+
+			// Sync PRD to GitHub issue once per batch (after all tasks processed)
+			// This prevents multiple concurrent syncs and reduces API calls
+			if (syncIssue && prdFile && result.tasksCompleted > 0) {
+				await syncPrdToIssue(prdFile, syncIssue, workDir);
+			}
+
+			// Log batch completion time
+			const batchDuration = formatDuration(Date.now() - batchStartTime);
+			logInfo(`Batch ${iteration} completed in ${batchDuration}`);
+			// If any retryable failure occurred, stop the run to allow retry later
+			// CHAINING LOGIC: Merge this batch's work into an integration branch
+			// Only do this if we have successful branches and we aren't stopping early
+			if (!skipMerge && !dryRun && !sawRetryableFailure && completedBranches.length > 0) {
+				// We need to find which branches were successful in THIS batch
+				// refetching from the results array is safer
+				const currentBatchBranches = results
+					.map(r => r.branchName) // This might be empty if failed
+					.filter(b => b && completedBranches.includes(b));
+					
+				if (currentBatchBranches.length > 0) {
+					let integrationBranch: string | undefined;
+					try {
+						logInfo(`Creating integration branch for batch ${iteration}...`);
+						// Create integration branch from current base
+						integrationBranch = await createIntegrationBranch(
+							iteration, 
+							currentBaseBranch, 
+							workDir,
+							originalBaseBranch // Use original base branch as prefix for namespacing
+						);
+						createdIntegrationBranches.push(integrationBranch);
+						
+						logInfo(`Merging ${currentBatchBranches.length} branch(es) into ${integrationBranch}...`);
+						
+						// Merge the batch's branches into the integration branch
+						// We use a cleaner merge function or the existing mergeCompletedBranches logic?
+						// Use mergeCompletedBranches but pointed at the integration branch
+						await mergeCompletedBranches(
+							currentBatchBranches,
+							integrationBranch,
+							engine,
+							workDir,
+							modelOverride,
+							engineArgs
+						);
+						
+						// Update current base branch for the next batch
+						currentBaseBranch = integrationBranch;
+						logSuccess(`Batch ${iteration} integrated into ${currentBaseBranch}`);
+						
+						// Remove merged branches from completedBranches to avoid re-merging them at the end
+						for (const branch of currentBatchBranches) {
+							const idx = completedBranches.indexOf(branch);
+							if (idx !== -1) {
+								completedBranches.splice(idx, 1);
+							}
+						}					
+					} catch (err) {
+						logError(`Failed to create integration branch: ${err}`);
+						
+						// Cleanup the orphaned integration branch if it was created
+						if (integrationBranch) {
+							try {
+								await deleteLocalBranch(integrationBranch, workDir, true);
+								logDebug(`Cleaned up orphaned integration branch: ${integrationBranch}`);
+							} catch (cleanupErr) {
+								logWarn(`Failed to cleanup orphaned branch ${integrationBranch}: ${cleanupErr}`);
+							}
+						}
+						
+						logWarn("Integration failed, stopping execution to preserve dependency chain.");
+						// Stop execution because subsequent batches depend on this integration
+						break;
+					}
+				}
+			}
+
+			if (sawRetryableFailure) {
+				logWarn("Stopping early due to retryable errors. Try again later.");
+				break;
+			}
+		}
+
+		// Merge phase: merge final integration branch back to base branch
+		// If we used integration branches, 'currentBaseBranch' holds the accumulated work.
+		// We need to merge 'currentBaseBranch' into 'originalBaseBranch'.
+		// We ALSO need to merge any leftover branches in 'completedBranches' (e.g. if a batch failed to integrate).
+
+		const branchesToMerge = [...completedBranches];
+		if (currentBaseBranch !== originalBaseBranch) {
+			branchesToMerge.push(currentBaseBranch);
+		}
+		
+		if (!skipMerge && !dryRun && branchesToMerge.length > 0) {
+			const git = simpleGit(workDir);
+			let stashed = false;
+			try {
+				const status = await git.status();
+				const hasChanges = status.files.length > 0 || status.not_added.length > 0;
+				if (hasChanges) {
+					await git.stash(["push", "-u", "-m", "ralphy-merge-stash"]);
+					stashed = true;
+					logDebug("Stashed local changes before merge phase");
+				}
+			} catch (stashErr) {
+				logWarn(`Failed to stash local changes: ${stashErr}`);
+			}
+
+			try {
+				if (currentBaseBranch !== originalBaseBranch) {
+					// We have a chain of integration branches.
+					logInfo(`Merging final integration branch ${currentBaseBranch} and ${completedBranches.length} other(s) into ${originalBaseBranch}`);
+				}
+				
+				await mergeCompletedBranches(
+					branchesToMerge,
+					originalBaseBranch,
+					engine,
+					workDir,
+					modelOverride,
+					engineArgs
+				);
+
+				// Restore starting branch if we're not already on it
+				const currentBranch = await getCurrentBranch(workDir);
+				if (currentBranch !== startingBranch) {
+					logDebug(`Restoring starting branch: ${startingBranch}`);
+					await returnToBaseBranch(startingBranch, workDir);
+				}
+			} finally {
+				if (stashed) {
+					try {
+						await git.stash(["pop"]);
+						logDebug("Restored stashed changes after merge phase");
+					} catch (stashErr) {
+						logWarn(`Failed to restore stashed changes: ${stashErr}`);
+					}
 				}
 			}
 		}
 
-		if (sawRetryableFailure) {
-			logWarn("Stopping early due to retryable errors. Try again later.");
-			break;
-		}
-	}
-
-	// Merge phase: merge final integration branch back to base branch
-	// If we used integration branches, 'currentBaseBranch' holds the accumulated work.
-	// We need to merge 'currentBaseBranch' into 'originalBaseBranch'.
-	// We ALSO need to merge any leftover branches in 'completedBranches' (e.g. if a batch failed to integrate).
-
-	const branchesToMerge = [...completedBranches];
-	if (currentBaseBranch !== originalBaseBranch) {
-		branchesToMerge.push(currentBaseBranch);
-	}
-	
-	if (!skipMerge && !dryRun && branchesToMerge.length > 0) {
-		const git = simpleGit(workDir);
-		let stashed = false;
+		return result;
+	} finally {
+		// 1. Restore starting branch FIRST so we can delete other branches safely
+		// This must happen regardless of whether we merged, skipped, or failed
 		try {
-			const status = await git.status();
-			const hasChanges = status.files.length > 0 || status.not_added.length > 0;
-			if (hasChanges) {
-				await git.stash(["push", "-u", "-m", "ralphy-merge-stash"]);
-				stashed = true;
-				logDebug("Stashed local changes before merge phase");
-			}
-		} catch (stashErr) {
-			logWarn(`Failed to stash local changes: ${stashErr}`);
-		}
-
-		try {
-			if (currentBaseBranch !== originalBaseBranch) {
-				// We have a chain of integration branches.
-				logInfo(`Merging final integration branch ${currentBaseBranch} and ${completedBranches.length} other(s) into ${originalBaseBranch}`);
-			}
-			
-			await mergeCompletedBranches(
-				branchesToMerge,
-				originalBaseBranch,
-				engine,
-				workDir,
-				modelOverride,
-				engineArgs
-			);
-
-			// Restore starting branch if we're not already on it
 			const currentBranch = await getCurrentBranch(workDir);
 			if (currentBranch !== startingBranch) {
 				logDebug(`Restoring starting branch: ${startingBranch}`);
 				await returnToBaseBranch(startingBranch, workDir);
 			}
-		} finally {
-			if (stashed) {
+		} catch (restoreErr) {
+			logWarn(`Failed to restore starting branch: ${restoreErr}`);
+		}
+
+		// 2. Cleanup all intermediate integration branches
+		if (createdIntegrationBranches.length > 0) {
+			// Cleanup distinct branches (deduplicate just in case)
+			const distinctBranches = [...new Set(createdIntegrationBranches)];
+			for (const branch of distinctBranches) {
 				try {
-					await git.stash(["pop"]);
-					logDebug("Restored stashed changes after merge phase");
-				} catch (stashErr) {
-					logWarn(`Failed to restore stashed changes: ${stashErr}`);
+					await deleteLocalBranch(branch, workDir, true);
+				} catch {
+					// Ignore errors
 				}
 			}
 		}
 	}
-
-	return result;
 }
 
 /**

--- a/cli/src/git/merge.ts
+++ b/cli/src/git/merge.ts
@@ -103,9 +103,17 @@ export async function createIntegrationBranch(
 	groupNum: number,
 	baseBranch: string,
 	workDir: string,
+	prefix?: string,
 ): Promise<string> {
 	const git: SimpleGit = simpleGit(workDir);
-	const branchName = `ralphy/integration-group-${groupNum}`;
+	
+	let branchName = `ralphy/integration-group-${groupNum}`;
+	
+	if (prefix) {
+		// Sanitize prefix: replace non-alphanumeric chars (mostly slashes) with dashes
+		const sanitizedPrefix = prefix.replace(/[^a-zA-Z0-9-]/g, "-");
+		branchName = `ralphy/${sanitizedPrefix}-integration-group-${groupNum}`;
+	}
 
 	// Checkout base branch first
 	await git.checkout(baseBranch);


### PR DESCRIPTION
## Description

This PR implements an advanced "chained" integration strategy for parallel task groups (batches) in the execution engine. Previously, tasks in parallel batches were isolated from each other until a final merge phase, which meant that a task in Group 2 could not see or build upon files created by Group 1.

With this change, `parallel.ts` now creates an **integration branch** after each batch completes. This integration branch:
1.  Is created from the current chain's base.
2.  Merges all successful branches from the current batch.
3.  Becomes the base branch for the *next* batch.

This ensures that tasks are executed in a sequential-parallel hybrid flow:
`Group 0` -> `Integration 1` -> `Group 1` (sees Group 0 work) -> `Integration 2` -> ... -> `Final Merge`

## Key Changes

### `cli/src/execution/parallel.ts`
-   Introduced `currentBaseBranch` to track the tip of the integration chain.
-   **Namespacing**: Integration branches are now prefixed with the sanitized base branch name (e.g., `ralphy/feature-database-integration-group-1`) to prevent collisions when running multiple instances on different features.
-   **Robust Merge Logic**: 
    -   Branches successfully integrated are removed from the pending list (`completedBranches`).
    -   The final merge phase combines the **integration chain tip** (if it moved) AND any remaining **pending branches** (e.g., from failed integration attempts).
    -   **Fail-Stop Protection**: If creating an integration branch fails (breaking the dependency chain), execution stops immediately.

### `cli/src/git/merge.ts`
-   Updated `createIntegrationBranch` to accept an optional `prefix`.
-   Sanitizes the prefix (replacing non-alphanumeric characters with dashes) for safe branch naming.

## Related Issues / Based on
-   Addresses the need for sequential context in parallel executions ([PR #14](https://github.com/michaelshimeles/ralphy/pull/14) logic ported to CLI).