### PR TITLE
Sort github tasks using jq

### DIFF
--- a/ralphy.sh
+++ b/ralphy.sh
@@ -1239,9 +1239,9 @@ get_tasks_in_group_yaml() {
 # ============================================
 
 get_tasks_github() {
-  local args=(--repo "$GITHUB_REPO" --state open --json number,title --limit 300)
+  local args=(--repo "$GITHUB_REPO" --state open --json number,title)
   [[ -n "$GITHUB_LABEL" ]] && args+=(--label "$GITHUB_LABEL")
-  gh issue list "${args[@]}" \
+  gh issue list "${args[@]}" --limit "${GITHUB_ISSUE_LIMIT:-300}" \
     --jq 'sort_by(.number) | .[] | "\(.number):\(.title)"' 2>/dev/null || true
 }
 


### PR DESCRIPTION
# Why
Users who want to use github issues in lieu of a prd.json want to work on issues in sequential order. Currently, ralphy defaults to the last issue created.

## What this PR changed
- modify `get_tasks_github` and `get_next_task_github` to use jq for sorting.