### PR TITLE
stack5:feat: add task source expansion and conversion wiring

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -169,6 +169,18 @@ ralphy --github owner/repo
 ralphy --github owner/repo --github-label "ready"
 ```
 
+## Task file conversion
+
+Convert task files between supported formats:
+
+```bash
+ralphy --convert-from PRD.md
+ralphy --convert-from tasks.yaml --convert-to tasks.csv
+ralphy --convert-from backlog.json --convert-to backlog.csv
+```
+
+If `--convert-to` is omitted, output defaults to a `.csv` file next to the input.
+
 ## Parallel Execution
 
 ```bash
@@ -313,6 +325,8 @@ ralphy --parallel --sandbox
 | `--init` | setup .ralphy/ config |
 | `--config` | show config |
 | `--add-rule "rule"` | add rule to config |
+| `--convert-from FILE` | convert a task file from markdown/yaml/json |
+| `--convert-to FILE` | output file path for conversion |
 
 ## Requirements
 

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -19,6 +19,8 @@ export function createProgram(): Command {
 		.option("--init", "Initialize .ralphy/ configuration")
 		.option("--config", "Show current configuration")
 		.option("--add-rule <rule>", "Add a rule to config")
+		.option("--convert-from <file>", "Convert task file from supported format")
+		.option("--convert-to <file>", "Output file for conversion")
 		.option("--no-tests, --skip-tests", "Skip running tests")
 		.option("--no-lint, --skip-lint", "Skip running lint")
 		.option("--fast", "Skip both tests and lint")
@@ -71,6 +73,8 @@ export function parseArgs(args: string[]): {
 	initMode: boolean;
 	showConfig: boolean;
 	addRule: string | undefined;
+	convertFrom: string | undefined;
+	convertTo: string | undefined;
 } {
 	// Find the -- separator and extract engine-specific arguments
 	const separatorIndex = args.indexOf("--");
@@ -167,6 +171,8 @@ export function parseArgs(args: string[]): {
 		initMode: opts.init || false,
 		showConfig: opts.config || false,
 		addRule: opts.addRule,
+		convertFrom: opts.convertFrom,
+		convertTo: opts.convertTo,
 	};
 }
 

--- a/cli/src/cli/commands/convert.ts
+++ b/cli/src/cli/commands/convert.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { extname } from "node:path";
 import pc from "picocolors";
 import { jsonToCsv, mdToCsv, yamlToCsv } from "../../tasks/converter.ts";
+import { parseCSV } from "../../tasks/csv.ts";
 import { logError, logInfo, logSuccess } from "../../ui/logger.ts";
 
 /**
@@ -52,7 +53,7 @@ export async function runConvert(options: {
 	}
 
 	// Count tasks
-	const taskCount = csvContent.split("\n").length - 1; // Subtract header
+	const taskCount = Math.max(0, parseCSV(csvContent).length - 1);
 
 	writeFileSync(to, csvContent, "utf-8");
 

--- a/cli/src/cli/commands/convert.ts
+++ b/cli/src/cli/commands/convert.ts
@@ -48,8 +48,7 @@ export async function runConvert(options: {
 		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		logError(`Error parsing ${from}: ${message}`);
-		throw err;
+		throw new Error(`Error parsing ${from}: ${message}`);
 	}
 
 	// Count tasks

--- a/cli/src/cli/commands/convert.ts
+++ b/cli/src/cli/commands/convert.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { extname } from "node:path";
+import pc from "picocolors";
+import { jsonToCsv, mdToCsv, yamlToCsv } from "../../tasks/converter.ts";
+import { logError, logInfo, logSuccess } from "../../ui/logger.ts";
+
+/**
+ * Convert PRD files between formats (YAML/MD/JSON -> CSV)
+ */
+export async function runConvert(options: {
+	from: string;
+	to: string;
+	verbose?: boolean;
+}): Promise<void> {
+	const { from, to, verbose } = options;
+
+	if (!existsSync(from)) {
+		throw new Error(`Source file not found: ${from}`);
+	}
+
+	const fromExt = extname(from).toLowerCase();
+	const content = readFileSync(from, "utf-8");
+	let csvContent = "";
+
+	try {
+		switch (fromExt) {
+			case ".yaml":
+			case ".yml":
+				if (verbose) logInfo(pc.dim("Converting YAML -> CSV..."));
+				csvContent = yamlToCsv(content);
+				break;
+
+			case ".md":
+			case ".markdown":
+				if (verbose) logInfo(pc.dim("Converting Markdown -> CSV..."));
+				csvContent = mdToCsv(content);
+				break;
+
+			case ".json":
+				if (verbose) logInfo(pc.dim("Converting JSON -> CSV..."));
+				csvContent = jsonToCsv(content);
+				break;
+
+			default:
+				throw new Error(
+					`Unsupported source format: ${fromExt}. Supported formats: .yaml, .yml, .md, .markdown, .json`,
+				);
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logError(`Error parsing ${from}: ${message}`);
+		throw err;
+	}
+
+	// Count tasks
+	const taskCount = csvContent.split("\n").length - 1; // Subtract header
+
+	writeFileSync(to, csvContent, "utf-8");
+
+	logSuccess(`Converted ${from} -> ${to}`);
+	logInfo(pc.dim(`  ${taskCount} tasks`));
+
+	// Show token savings estimate
+	const originalTokens = Math.ceil(content.length / 4); // Rough token estimate
+	const csvTokens = Math.ceil(csvContent.length / 4);
+	// BUG FIX: Prevent division by zero when original file is empty
+	const savings = originalTokens === 0 ? 0 : Math.round((1 - csvTokens / originalTokens) * 100);
+
+	if (savings > 0) {
+		logInfo(pc.green(`  ~${savings}% token savings (${originalTokens} -> ${csvTokens} tokens)`));
+	}
+}

--- a/cli/src/cli/commands/index.ts
+++ b/cli/src/cli/commands/index.ts
@@ -1,4 +1,5 @@
-export * from "./init.ts";
 export * from "./config.ts";
-export * from "./task.ts";
+export * from "./convert.ts";
+export * from "./init.ts";
 export * from "./run.ts";
+export * from "./task.ts";

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -40,19 +40,19 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 		if (!existsSync(options.prdFile)) {
 			logError(`${options.prdFile} not found in current directory`);
 			logInfo(`Create a ${options.prdFile} file with tasks`);
-			process.exit(1);
+			throw new Error(`PRD source not found: ${options.prdFile}`);
 		}
 	} else if (options.prdSource === "markdown-folder") {
 		if (!existsSync(options.prdFile)) {
 			logError(`PRD folder ${options.prdFile} not found`);
 			logInfo(`Create a ${options.prdFile}/ folder with markdown files containing tasks`);
-			process.exit(1);
+			throw new Error(`PRD folder not found: ${options.prdFile}`);
 		}
 	}
 
 	if (options.prdSource === "github" && !options.githubRepo) {
 		logError("GitHub repository not specified. Use --github owner/repo");
-		process.exit(1);
+		throw new Error("GitHub repository not specified");
 	}
 
 	// Check engine availability
@@ -61,7 +61,7 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 
 	if (!available) {
 		logError(`${engine.name} CLI not found. Make sure '${engine.cliCommand}' is in your PATH.`);
-		process.exit(1);
+		throw new Error(`${engine.name} CLI not available`);
 	}
 
 	// Create task source with caching for better performance
@@ -91,7 +91,7 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 			logError("Cannot run in parallel/branch mode: repository has no commits yet.");
 			logInfo("Please make an initial commit first:");
 			logInfo('  git add . && git commit -m "Initial commit"');
-			process.exit(1);
+			throw new Error("Repository has no commits yet");
 		}
 	}
 
@@ -195,6 +195,6 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 	}
 
 	if (result.tasksFailed > 0) {
-		process.exit(1);
+		throw new Error(`${result.tasksFailed} task(s) failed`);
 	}
 }

--- a/cli/src/cli/commands/task.ts
+++ b/cli/src/cli/commands/task.ts
@@ -28,7 +28,7 @@ export async function runTask(task: string, options: RuntimeOptions): Promise<vo
 
 	if (!available) {
 		logError(`${engine.name} CLI not found. Make sure '${engine.cliCommand}' is in your PATH.`);
-		process.exit(1);
+		throw new Error(`${engine.name} CLI not available`);
 	}
 
 	logInfo(`Running task with ${engine.name}...`);
@@ -129,7 +129,7 @@ export async function runTask(task: string, options: RuntimeOptions): Promise<vo
 				tasksFailed: 1,
 			});
 			notifyTaskFailed(task, result.error || "Unknown error");
-			process.exit(1);
+			throw new Error(result.error || "Unknown error");
 		}
 	} catch (error) {
 		const errorMsg = error instanceof Error ? error.message : String(error);
@@ -140,6 +140,6 @@ export async function runTask(task: string, options: RuntimeOptions): Promise<vo
 			tasksFailed: 1,
 		});
 		notifyTaskFailed(task, errorMsg);
-		process.exit(1);
+		throw error instanceof Error ? error : new Error(errorMsg);
 	}
 }

--- a/cli/src/config/constants.ts
+++ b/cli/src/config/constants.ts
@@ -1,0 +1,80 @@
+export const PROGRESS_UPDATE_INTERVAL = 500;
+export const HEARTBEAT_INTERVAL = 5000;
+// Default retry count used by CLI/runtime options.
+export const DEFAULT_MAX_RETRIES = 3;
+// Legacy alias retained for older modules.
+export const MAX_RETRIES = DEFAULT_MAX_RETRIES;
+export const UI_LABELS = {
+	PLANNING: "[PLANNING]",
+	EXECUTION: "[EXECUTION]",
+	DONE: "[DONE]",
+	FAIL: "[FAIL]",
+	OK: "[OK]",
+};
+export const SPINNER_CHARS = ["|", "/", "-", "\\"];
+export const MAX_EXECUTION_TIME = 300000; // 5 minutes
+export const PROGRESS_POLL_INTERVAL = 2000;
+export const WATCHER_DEBOUNCE = 250;
+export const PLANNING_COOLDOWN = 2000;
+
+// CLI Defaults
+export const DEFAULT_RETRY_DELAY = 5;
+export const DEFAULT_MAX_PARALLEL = 3;
+export const DEFAULT_MAX_REPLANS = 3;
+export const DEFAULT_MAX_ITERATIONS = 0;
+
+// AI Engine Defaults
+export const DEFAULT_AI_ENGINE_TIMEOUT_MS = 80 * 60 * 1000; // 80 minutes
+export const STREAM_HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds without output = potential hang
+
+// Parallel Execution
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const INITIAL_POOL_SIZE_MULTIPLIER = 1;
+export const MAX_POOL_SIZE_MULTIPLIER = 5;
+export const PLANNING_CONCURRENCY = 5;
+export const POOL_INCREMENT = 2;
+
+// Progress Monitoring
+export const MAX_OPERATIONS_HISTORY = 10;
+export const RECENT_ACTIONS_COUNT = 3;
+export const FIND_WORKTREE_RETRIES = 20;
+export const MAX_DISPLAYED_ACTIONS = 3;
+
+// Sandbox Management
+export const DEFAULT_MAX_SANDBOX_AGE_MS = 60 * 60 * 1000; // 1 hour
+export const SANDBOX_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const SANDBOX_BACKGROUND_CLEANUP_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+export const MS_PER_MINUTE = 60000;
+export const CLEANUP_DELAY_MS = 5000;
+export const COPY_BACK_CONCURRENCY = 10;
+export const SANDBOX_DIR_PREFIX = "agent-";
+export const SANDBOX_SUFFIX = "";
+export const DEFAULT_IGNORE_PATTERNS = [
+	".git",
+	"node_modules",
+	".ralphy-sandboxes",
+	".ralphy-worktrees",
+	".ralphy",
+	"agent-*",
+	"sandbox-*",
+];
+
+// File Utilities
+export const MAX_FILE_SIZE_FOR_HASH = 2 * 1024 * 1024; // 2MB
+export const DEFAULT_RECURSION_DEPTH = 5;
+
+// Lock Management
+export const LOCK_TIMEOUT_MS = 30000; // 30 seconds
+export const LOCK_MAX_LOCKS = 5000; // Maximum number of locks
+export const LOCK_DIR = ".ralphy/locks"; // Lock directory
+export const LOCK_CLEANUP_INTERVAL_MS = 60000; // 1 minute between cleanups
+
+// Path Constants
+export const SANDBOX_DIR = ".ralphy-worktrees";
+export const PLANNING_CACHE_FILE = "planning-cache.json";
+
+// Hash Store Constants
+export const HASH_STORE_DIR = ".ralphy-hashes";
+export const HASH_STORE_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const HASH_REFERENCE_SUFFIX = ".hash-ref";
+export const ENABLE_HASH_STORE = true; // Feature flag

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -17,6 +17,7 @@ export const NotificationsSchema = z.object({
 	discord_webhook: z.string().default(""),
 	slack_webhook: z.string().default(""),
 	custom_webhook: z.string().default(""),
+	telemetry_webhook: z.string().default(""),
 });
 
 /**
@@ -109,6 +110,8 @@ export interface RuntimeOptions {
 	browserEnabled: "auto" | "true" | "false";
 	/** Override default model for the engine */
 	modelOverride?: string;
+	/** Enable comprehensive OpenCode debugging */
+	debugOpenCode?: boolean;
 	/** Skip automatic branch merging after parallel execution */
 	skipMerge?: boolean;
 	/** Use lightweight sandboxes instead of git worktrees for parallel execution */
@@ -142,4 +145,5 @@ export const DEFAULT_OPTIONS: RuntimeOptions = {
 	githubLabel: "",
 	autoCommit: true,
 	browserEnabled: "auto",
+	debugOpenCode: false,
 };

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -109,7 +109,12 @@ async function runAgentInWorktree(
 		logDebug(`Agent ${agentNum}: Created worktree at ${worktreeDir}`);
 
 		// Copy PRD file or folder to worktree
-		if (prdSource === "markdown" || prdSource === "yaml" || prdSource === "json") {
+		if (
+			prdSource === "markdown" ||
+			prdSource === "yaml" ||
+			prdSource === "json" ||
+			prdSource === "csv"
+		) {
 			const srcPath = join(originalDir, safePrdPath);
 			const destPath = join(worktreeDir, safePrdPath);
 			if (existsSync(srcPath)) {
@@ -209,7 +214,12 @@ async function runAgentInSandbox(
 		);
 
 		// Copy PRD file or folder to sandbox (same as worktree mode)
-		if (prdSource === "markdown" || prdSource === "yaml" || prdSource === "json") {
+		if (
+			prdSource === "markdown" ||
+			prdSource === "yaml" ||
+			prdSource === "json" ||
+			prdSource === "csv"
+		) {
 			const srcPath = join(originalDir, safePrdPath);
 			const destPath = join(sandboxDir, safePrdPath);
 			if (existsSync(srcPath)) {

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, cpSync, existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 import simpleGit from "simple-git";
 import { PROGRESS_FILE, RALPHY_DIR } from "../config/loader.ts";
 import { logTaskProgress } from "../config/writer.ts";
@@ -41,6 +41,30 @@ interface ParallelAgentResult {
 	usedSandbox?: boolean;
 }
 
+function resolveSafeRelativePath(baseDir: string, candidatePath: string): string | null {
+	if (!candidatePath || isAbsolute(candidatePath)) {
+		return null;
+	}
+
+	const normalized = normalize(candidatePath);
+	const resolved = resolve(baseDir, normalized);
+	const rel = relative(baseDir, resolved);
+
+	if (rel === "" || rel === ".") {
+		return normalized;
+	}
+
+	if (rel.startsWith(`..${sep}`) || rel === "..") {
+		return null;
+	}
+
+	if (isAbsolute(rel)) {
+		return null;
+	}
+
+	return rel;
+}
+
 /**
  * Run a single agent in a worktree
  */
@@ -66,6 +90,11 @@ async function runAgentInWorktree(
 	let branchName = "";
 
 	try {
+		const safePrdPath = resolveSafeRelativePath(originalDir, prdFile);
+		if (!safePrdPath) {
+			throw new Error(`Invalid PRD path outside project: ${prdFile}`);
+		}
+
 		// Create worktree
 		const worktree = await createAgentWorktree(
 			task.title,
@@ -81,15 +110,17 @@ async function runAgentInWorktree(
 
 		// Copy PRD file or folder to worktree
 		if (prdSource === "markdown" || prdSource === "yaml" || prdSource === "json") {
-			const srcPath = join(originalDir, prdFile);
-			const destPath = join(worktreeDir, prdFile);
+			const srcPath = join(originalDir, safePrdPath);
+			const destPath = join(worktreeDir, safePrdPath);
 			if (existsSync(srcPath)) {
+				mkdirSync(dirname(destPath), { recursive: true });
 				copyFileSync(srcPath, destPath);
 			}
 		} else if (prdSource === "markdown-folder" && prdIsFolder) {
-			const srcPath = join(originalDir, prdFile);
-			const destPath = join(worktreeDir, prdFile);
+			const srcPath = join(originalDir, safePrdPath);
+			const destPath = join(worktreeDir, safePrdPath);
 			if (existsSync(srcPath)) {
+				mkdirSync(dirname(destPath), { recursive: true });
 				cpSync(srcPath, destPath, { recursive: true });
 			}
 		}
@@ -161,6 +192,11 @@ async function runAgentInSandbox(
 	const branchName = "";
 
 	try {
+		const safePrdPath = resolveSafeRelativePath(originalDir, prdFile);
+		if (!safePrdPath) {
+			throw new Error(`Invalid PRD path outside project: ${prdFile}`);
+		}
+
 		// Create sandbox
 		const sandboxResult = await createSandbox({
 			originalDir,
@@ -174,15 +210,17 @@ async function runAgentInSandbox(
 
 		// Copy PRD file or folder to sandbox (same as worktree mode)
 		if (prdSource === "markdown" || prdSource === "yaml" || prdSource === "json") {
-			const srcPath = join(originalDir, prdFile);
-			const destPath = join(sandboxDir, prdFile);
+			const srcPath = join(originalDir, safePrdPath);
+			const destPath = join(sandboxDir, safePrdPath);
 			if (existsSync(srcPath)) {
+				mkdirSync(dirname(destPath), { recursive: true });
 				copyFileSync(srcPath, destPath);
 			}
 		} else if (prdSource === "markdown-folder" && prdIsFolder) {
-			const srcPath = join(originalDir, prdFile);
-			const destPath = join(sandboxDir, prdFile);
+			const srcPath = join(originalDir, safePrdPath);
+			const destPath = join(sandboxDir, safePrdPath);
 			if (existsSync(srcPath)) {
+				mkdirSync(dirname(destPath), { recursive: true });
 				cpSync(srcPath, destPath, { recursive: true });
 			}
 		}
@@ -381,12 +419,13 @@ export async function runParallel(
 		// Run agents in parallel (using sandbox or worktree mode)
 		const promises = batch.map((task) => {
 			globalAgentNum++;
+			const agentId = globalAgentNum;
 
 			const runInSandbox = () =>
 				runAgentInSandbox(
 					engine,
 					task,
-					globalAgentNum,
+					agentId,
 					getSandboxBase(workDir),
 					workDir,
 					prdSource,
@@ -408,7 +447,7 @@ export async function runParallel(
 			return runAgentInWorktree(
 				engine,
 				task,
-				globalAgentNum,
+				agentId,
 				baseBranch,
 				isolationBase,
 				workDir,
@@ -424,7 +463,7 @@ export async function runParallel(
 				engineArgs,
 			).then((res) => {
 				if (shouldFallbackToSandbox(res.error)) {
-					logWarn(`Agent ${globalAgentNum}: Worktree unavailable, retrying in sandbox mode.`);
+					logWarn(`Agent ${agentId}: Worktree unavailable, retrying in sandbox mode.`);
 					if (res.worktreeDir) {
 						cleanupAgentWorktree(res.worktreeDir, res.branchName, workDir).catch(() => {
 							// Ignore cleanup failures during fallback

--- a/cli/src/execution/retry.ts
+++ b/cli/src/execution/retry.ts
@@ -34,7 +34,7 @@ export function calculateBackoffDelay(
 	useJitter: boolean,
 ): number {
 	// Exponential backoff: baseDelay * 2^(attempt-1)
-	let delay = baseDelayMs * Math.pow(2, attempt - 1);
+	let delay = baseDelayMs * 2 ** (attempt - 1);
 
 	// Cap at maximum delay
 	delay = Math.min(delay, maxDelayMs);

--- a/cli/src/execution/sandbox-git.ts
+++ b/cli/src/execution/sandbox-git.ts
@@ -12,7 +12,7 @@ class GitMutex {
 	private queue: Promise<void> = Promise.resolve();
 
 	async acquire<T>(fn: () => Promise<T>): Promise<T> {
-		let release: () => void;
+		let release: (() => void) | undefined;
 		const next = new Promise<void>((resolve) => {
 			release = resolve;
 		});
@@ -22,7 +22,7 @@ class GitMutex {
 		try {
 			return await fn();
 		} finally {
-			release!();
+			release?.();
 		}
 	}
 }

--- a/cli/src/execution/sandbox.ts
+++ b/cli/src/execution/sandbox.ts
@@ -32,21 +32,27 @@ export async function rmRF(path: string): Promise<void> {
 			// Using force: true and recursive: true is standard
 			rmSync(path, { recursive: true, force: true });
 			return;
-		} catch (err: any) {
-			const isLockError = err.code === "EBUSY" || err.code === "EPERM" || err.code === "ENOTEMPTY";
+		} catch (err: unknown) {
+			const errorCode =
+				typeof err === "object" && err !== null && "code" in err
+					? String((err as { code?: string }).code)
+					: "";
+			const isLockError =
+				errorCode === "EBUSY" || errorCode === "EPERM" || errorCode === "ENOTEMPTY";
 
 			if (isLockError && i < retries - 1) {
 				// Wait with exponential backoff: 500, 1000, 2000, 4000...
-				const delay = 500 * Math.pow(2, i);
+				const delay = 500 * 2 ** i;
 				await new Promise((resolve) => setTimeout(resolve, delay));
 				continue;
 			}
 
 			// On final failure for lock errors, log warning and swallow.
 			// For non-lock errors (any time), throw immediately.
+			const errorMessage = err instanceof Error ? err.message : String(err);
 			if (isLockError && i === retries - 1) {
 				logWarn(
-					`Failed to clean up ${path} after ${retries} attempts: ${err.message}. This may be due to a file lock. Proceeding anyway.`,
+					`Failed to clean up ${path} after ${retries} attempts: ${errorMessage}. This may be due to a file lock. Proceeding anyway.`,
 				);
 			} else {
 				throw err;
@@ -252,7 +258,6 @@ export function verifySandboxIsolation(sandboxDir: string, symlinkDirs: string[]
 				const stat = lstatSync(sandboxPath);
 				if (stat.isSymbolicLink()) {
 					// Good - it's a symlink
-					continue;
 				}
 			} catch {
 				// Error checking - assume not isolated

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -22,7 +22,7 @@ process.on("unhandledRejection", (reason, promise) => {
 	// Don't crash, but log and continue - prevent uncaught exception
 });
 
-	// Handle uncaught exceptions globally
+// Handle uncaught exceptions globally
 process.on("uncaughtException", (error) => {
 	logError(`Uncaught Exception: ${error.message}`);
 	logError(`Stack: ${error.stack}`);
@@ -33,9 +33,7 @@ process.on("uncaughtException", (error) => {
 			);
 		})
 		.finally(() => {
-			// Set exit code instead of calling exit immediately
-			// This allows the cleanup promise to resolve before Node.js exits
-			process.exitCode = 1;
+			process.exit(1);
 		});
 });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -22,19 +22,21 @@ process.on("unhandledRejection", (reason, promise) => {
 	// Don't crash, but log and continue - prevent uncaught exception
 });
 
-// Handle uncaught exceptions globally
-process.on("uncaughtException", async (error) => {
+	// Handle uncaught exceptions globally
+process.on("uncaughtException", (error) => {
 	logError(`Uncaught Exception: ${error.message}`);
 	logError(`Stack: ${error.stack}`);
-	// Perform cleanup before exiting
-	try {
-		await runCleanup();
-	} catch (cleanupError) {
-		logError(
-			`Cleanup failed during uncaught exception: ${cleanupError instanceof Error ? cleanupError.message : cleanupError}`,
-		);
-	}
-	process.exit(1);
+	runCleanup()
+		.catch((cleanupError: unknown) => {
+			logError(
+				`Cleanup failed during uncaught exception: ${cleanupError instanceof Error ? cleanupError.message : cleanupError}`,
+			);
+		})
+		.finally(() => {
+			// Set exit code instead of calling exit immediately
+			// This allows the cleanup promise to resolve before Node.js exits
+			process.exitCode = 1;
+		});
 });
 
 async function main(): Promise<void> {
@@ -51,7 +53,7 @@ async function main(): Promise<void> {
 
 		// Handle --convert-from
 		if (convertFrom) {
-			const outputFile = convertTo || convertFrom.replace(/\.(yaml|yml|md|json)$/i, ".csv");
+			const outputFile = convertTo || `${convertFrom.replace(/\.[^.]+$/, "")}.csv`;
 			await runConvert({ from: convertFrom, to: outputFile, verbose: options.verbose });
 			return;
 		}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,11 +1,41 @@
 #!/usr/bin/env bun
 import { parseArgs } from "./cli/args.ts";
 import { addRule, showConfig } from "./cli/commands/config.ts";
+import { runConvert } from "./cli/commands/convert.ts";
 import { runInit } from "./cli/commands/init.ts";
 import { runLoop } from "./cli/commands/run.ts";
 import { runTask } from "./cli/commands/task.ts";
-import { flushAllProgressWrites } from "./config/writer.ts";
 import { logError } from "./ui/logger.ts";
+import { runCleanup, setupSignalHandlers } from "./utils/cleanup.ts";
+import { standardizeError } from "./utils/errors.ts";
+
+// Setup global cleanup and signal handlers
+setupSignalHandlers();
+
+// Handle unhandled promise rejections globally
+process.on("unhandledRejection", (reason, promise) => {
+	// BUG FIX: Preserve error stack traces for better debugging
+	const errorMessage =
+		reason instanceof Error ? `${reason.message}\n${reason.stack}` : String(reason);
+	logError(`Unhandled Promise Rejection: ${errorMessage}`);
+	logError(`Promise: ${promise}`);
+	// Don't crash, but log and continue - prevent uncaught exception
+});
+
+// Handle uncaught exceptions globally
+process.on("uncaughtException", async (error) => {
+	logError(`Uncaught Exception: ${error.message}`);
+	logError(`Stack: ${error.stack}`);
+	// Perform cleanup before exiting
+	try {
+		await runCleanup();
+	} catch (cleanupError) {
+		logError(
+			`Cleanup failed during uncaught exception: ${cleanupError instanceof Error ? cleanupError.message : cleanupError}`,
+		);
+	}
+	process.exit(1);
+});
 
 async function main(): Promise<void> {
 	try {
@@ -15,7 +45,16 @@ async function main(): Promise<void> {
 			initMode,
 			showConfig: showConfigMode,
 			addRule: rule,
+			convertFrom,
+			convertTo,
 		} = parseArgs(process.argv);
+
+		// Handle --convert-from
+		if (convertFrom) {
+			const outputFile = convertTo || convertFrom.replace(/\.(yaml|yml|md|json)$/i, ".csv");
+			await runConvert({ from: convertFrom, to: outputFile, verbose: options.verbose });
+			return;
+		}
 
 		// Handle --init
 		if (initMode) {
@@ -44,12 +83,11 @@ async function main(): Promise<void> {
 		// PRD loop mode
 		await runLoop(options);
 	} catch (error) {
-		logError(error instanceof Error ? error.message : String(error));
-		process.exitCode = 1;
-	} finally {
-		// Ensure all progress writes are flushed before exit
-		await flushAllProgressWrites();
+		logError(standardizeError(error).message);
+		await runCleanup();
+		process.exit(1);
 	}
 }
 
-main();
+// BUG FIX: Await main() to prevent floating promise and ensure proper error handling
+await main();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,13 +13,19 @@ import { standardizeError } from "./utils/errors.ts";
 setupSignalHandlers();
 
 // Handle unhandled promise rejections globally
-process.on("unhandledRejection", (reason, promise) => {
-	// BUG FIX: Preserve error stack traces for better debugging
+process.on("unhandledRejection", (reason, _promise) => {
 	const errorMessage =
 		reason instanceof Error ? `${reason.message}\n${reason.stack}` : String(reason);
 	logError(`Unhandled Promise Rejection: ${errorMessage}`);
-	logError(`Promise: ${promise}`);
-	// Don't crash, but log and continue - prevent uncaught exception
+	runCleanup()
+		.catch((cleanupError: unknown) => {
+			logError(
+				`Cleanup failed during unhandled rejection: ${cleanupError instanceof Error ? cleanupError.message : cleanupError}`,
+			);
+		})
+		.finally(() => {
+			process.exit(1);
+		});
 });
 
 // Handle uncaught exceptions globally

--- a/cli/src/tasks/converter.ts
+++ b/cli/src/tasks/converter.ts
@@ -1,39 +1,8 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";
-import { parseCSV } from "./csv.ts";
-
-function sanitizeCsvCell(value: string): string {
-	if (/^[=+\-@]/.test(value)) {
-		return `'${value}`;
-	}
-	return value;
-}
-
-/**
- * Escape a value for CSV output
- * Handles commas, quotes, newlines, and carriage returns
- */
-function escapeCSV(value: string): string {
-	// Defensive: ensure value is a string
-	if (value === null || value === undefined) {
-		return "";
-	}
-	const strValue = String(value);
-	const safeValue = sanitizeCsvCell(strValue);
-	// Escape if contains special characters: comma, quote, newline, or carriage return
-	if (/[",\n\r]/.test(safeValue)) {
-		return `"${safeValue.replace(/"/g, '""')}"`;
-	}
-	return safeValue;
-}
-
-/**
- * Convert rows to CSV string
- */
-function toCSV(rows: string[][]): string {
-	return rows.map((row) => row.map(escapeCSV).join(",")).join("\n");
-}
+import { parseCSV, rowsToCsv } from "./csv.ts";
+import { hasPrototypePollution } from "./yaml.ts";
 
 /**
  * Truncate description to save tokens
@@ -61,6 +30,9 @@ interface YamlTaskFile {
  */
 export function yamlToCsv(yamlContent: string): string {
 	const data = YAML.parse(yamlContent) as YamlTaskFile;
+	if (hasPrototypePollution(data)) {
+		throw new Error("YAML contains disallowed prototype pollution keys");
+	}
 	const tasks = data.tasks || [];
 
 	const rows: string[][] = [["id", "title", "done", "group", "desc"]];
@@ -74,7 +46,7 @@ export function yamlToCsv(yamlContent: string): string {
 			truncateDesc(t.description),
 		]);
 	}
-	return toCSV(rows);
+	return rowsToCsv(rows);
 }
 
 /**
@@ -102,7 +74,7 @@ export function mdToCsv(mdContent: string): string {
 		}
 	}
 
-	return toCSV(rows);
+	return rowsToCsv(rows);
 }
 
 interface JsonTask {
@@ -125,7 +97,9 @@ export function jsonToCsv(jsonContent: string): string {
 	} catch {
 		return "id,title,done,group,desc\n";
 	}
-	const tasks: JsonTask[] = Array.isArray(data) ? data : (data as { tasks?: JsonTask[] })?.tasks || [];
+	const tasks: JsonTask[] = Array.isArray(data)
+		? data
+		: (data as { tasks?: JsonTask[] })?.tasks || [];
 
 	const rows: string[][] = [["id", "title", "done", "group", "desc"]];
 	for (let i = 0; i < tasks.length; i++) {
@@ -138,7 +112,7 @@ export function jsonToCsv(jsonContent: string): string {
 			truncateDesc(t.description || t.body),
 		]);
 	}
-	return toCSV(rows);
+	return rowsToCsv(rows);
 }
 
 interface SkillFrontmatter {
@@ -149,7 +123,9 @@ interface SkillFrontmatter {
 /**
  * Parse SKILL.md file with YAML frontmatter
  */
-function parseSkillFile(filePath: string): { name: string; description: string; content: string } | null {
+function parseSkillFile(
+	filePath: string,
+): { name: string; description: string; content: string } | null {
 	try {
 		const content = readFileSync(filePath, "utf-8");
 		const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
@@ -221,7 +197,7 @@ export function skillsToCsv(skillDir: string): string {
 	for (const s of skills) {
 		rows.push([s.name, s.desc, s.content]);
 	}
-	return toCSV(rows);
+	return rowsToCsv(rows);
 }
 
 /**
@@ -250,5 +226,5 @@ export function allSkillsToCsv(skillDirs: string[]): string {
 	}
 
 	if (allRows.length <= 1) return "";
-	return toCSV(allRows);
+	return rowsToCsv(allRows);
 }

--- a/cli/src/tasks/converter.ts
+++ b/cli/src/tasks/converter.ts
@@ -132,6 +132,9 @@ function parseSkillFile(
 
 		if (frontmatterMatch) {
 			const frontmatter = YAML.parse(frontmatterMatch[1]) as SkillFrontmatter;
+			if (hasPrototypePollution(frontmatter)) {
+				return null;
+			}
 			const body = frontmatterMatch[2].trim();
 
 			return {

--- a/cli/src/tasks/converter.ts
+++ b/cli/src/tasks/converter.ts
@@ -1,0 +1,254 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import YAML from "yaml";
+import { parseCSV } from "./csv.ts";
+
+function sanitizeCsvCell(value: string): string {
+	if (/^[=+\-@]/.test(value)) {
+		return `'${value}`;
+	}
+	return value;
+}
+
+/**
+ * Escape a value for CSV output
+ * Handles commas, quotes, newlines, and carriage returns
+ */
+function escapeCSV(value: string): string {
+	// Defensive: ensure value is a string
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const strValue = String(value);
+	const safeValue = sanitizeCsvCell(strValue);
+	// Escape if contains special characters: comma, quote, newline, or carriage return
+	if (/[",\n\r]/.test(safeValue)) {
+		return `"${safeValue.replace(/"/g, '""')}"`;
+	}
+	return safeValue;
+}
+
+/**
+ * Convert rows to CSV string
+ */
+function toCSV(rows: string[][]): string {
+	return rows.map((row) => row.map(escapeCSV).join(",")).join("\n");
+}
+
+/**
+ * Truncate description to save tokens
+ */
+function truncateDesc(desc: string | undefined, maxLen = 80): string {
+	if (!desc) return "";
+	const clean = desc.replace(/\s+/g, " ").trim();
+	if (clean.length <= maxLen) return clean;
+	return `${clean.slice(0, maxLen - 3)}...`;
+}
+
+interface YamlTask {
+	title: string;
+	completed?: boolean;
+	parallel_group?: number;
+	description?: string;
+}
+
+interface YamlTaskFile {
+	tasks: YamlTask[];
+}
+
+/**
+ * Convert YAML task file content to CSV format
+ */
+export function yamlToCsv(yamlContent: string): string {
+	const data = YAML.parse(yamlContent) as YamlTaskFile;
+	const tasks = data.tasks || [];
+
+	const rows: string[][] = [["id", "title", "done", "group", "desc"]];
+	for (let i = 0; i < tasks.length; i++) {
+		const t = tasks[i];
+		rows.push([
+			String(i + 1),
+			t.title || "",
+			t.completed ? "1" : "0",
+			String(t.parallel_group || 0),
+			truncateDesc(t.description),
+		]);
+	}
+	return toCSV(rows);
+}
+
+/**
+ * Convert Markdown task file content to CSV format
+ */
+export function mdToCsv(mdContent: string): string {
+	const lines = mdContent.replace(/\r\n/g, "\n").split("\n");
+	const rows: string[][] = [["id", "title", "done", "group", "desc"]];
+
+	let id = 1;
+	for (const line of lines) {
+		// Match incomplete tasks: "- [ ] Task description"
+		const incompleteMatch = line.match(/^- \[ \] (.+)$/);
+		if (incompleteMatch) {
+			rows.push([String(id), incompleteMatch[1].trim(), "0", "0", ""]);
+			id++;
+			continue;
+		}
+
+		// Match completed tasks: "- [x] Task description"
+		const completeMatch = line.match(/^- \[x\] (.+)$/i);
+		if (completeMatch) {
+			rows.push([String(id), completeMatch[1].trim(), "1", "0", ""]);
+			id++;
+		}
+	}
+
+	return toCSV(rows);
+}
+
+interface JsonTask {
+	id?: string | number;
+	title: string;
+	completed?: boolean;
+	parallel_group?: number;
+	parallelGroup?: number;
+	description?: string;
+	body?: string;
+}
+
+/**
+ * Convert JSON task file content to CSV format
+ */
+export function jsonToCsv(jsonContent: string): string {
+	let data: unknown;
+	try {
+		data = JSON.parse(jsonContent);
+	} catch {
+		return "id,title,done,group,desc\n";
+	}
+	const tasks: JsonTask[] = Array.isArray(data) ? data : (data as { tasks?: JsonTask[] })?.tasks || [];
+
+	const rows: string[][] = [["id", "title", "done", "group", "desc"]];
+	for (let i = 0; i < tasks.length; i++) {
+		const t = tasks[i];
+		rows.push([
+			String(t.id || i + 1),
+			t.title || "",
+			t.completed ? "1" : "0",
+			String(t.parallel_group || t.parallelGroup || 0),
+			truncateDesc(t.description || t.body),
+		]);
+	}
+	return toCSV(rows);
+}
+
+interface SkillFrontmatter {
+	name?: string;
+	description?: string;
+}
+
+/**
+ * Parse SKILL.md file with YAML frontmatter
+ */
+function parseSkillFile(filePath: string): { name: string; description: string; content: string } | null {
+	try {
+		const content = readFileSync(filePath, "utf-8");
+		const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+
+		if (frontmatterMatch) {
+			const frontmatter = YAML.parse(frontmatterMatch[1]) as SkillFrontmatter;
+			const body = frontmatterMatch[2].trim();
+
+			return {
+				name: frontmatter.name || "",
+				description: frontmatter.description || "",
+				content: truncateDesc(body, 200),
+			};
+		}
+
+		// No frontmatter, use filename as name
+		const name = filePath.split(/[/\\]/).pop()?.replace(".md", "") || "";
+		return {
+			name,
+			description: "",
+			content: truncateDesc(content, 200),
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Convert a skills directory to compact CSV format
+ */
+export function skillsToCsv(skillDir: string): string {
+	if (!existsSync(skillDir)) return "";
+
+	const skills: Array<{ name: string; desc: string; content: string }> = [];
+
+	// Find SKILL.md files in the directory
+	const entries = readdirSync(skillDir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = join(skillDir, entry.name);
+
+		if (entry.isDirectory()) {
+			// Check for SKILL.md inside subdirectory
+			const skillFile = join(fullPath, "SKILL.md");
+			if (existsSync(skillFile)) {
+				const parsed = parseSkillFile(skillFile);
+				if (parsed) {
+					skills.push({
+						name: parsed.name || entry.name,
+						desc: parsed.description,
+						content: parsed.content,
+					});
+				}
+			}
+		} else if (entry.name.endsWith(".md")) {
+			const parsed = parseSkillFile(fullPath);
+			if (parsed) {
+				skills.push({
+					name: parsed.name || entry.name.replace(".md", ""),
+					desc: parsed.description,
+					content: parsed.content,
+				});
+			}
+		}
+	}
+
+	if (skills.length === 0) return "";
+
+	const rows: string[][] = [["skill", "desc", "summary"]];
+	for (const s of skills) {
+		rows.push([s.name, s.desc, s.content]);
+	}
+	return toCSV(rows);
+}
+
+/**
+ * Convert multiple skill directories to combined CSV
+ */
+export function allSkillsToCsv(skillDirs: string[]): string {
+	const allRows: string[][] = [["skill", "desc", "summary"]];
+
+	for (const dir of skillDirs) {
+		const csv = skillsToCsv(dir);
+		if (csv) {
+			// Skip header, add data rows
+			const lines = csv.split("\n");
+			for (let i = 1; i < lines.length; i++) {
+				const line = lines[i].trim();
+				if (line) {
+					// Use proper CSV parser to handle quoted values and commas
+					const parsedRows = parseCSV(line);
+					// parseCSV returns array of rows, we just want the first (current) row
+					if (parsedRows.length > 0) {
+						allRows.push(parsedRows[0]);
+					}
+				}
+			}
+		}
+	}
+
+	if (allRows.length <= 1) return "";
+	return toCSV(allRows);
+}

--- a/cli/src/tasks/converter.ts
+++ b/cli/src/tasks/converter.ts
@@ -209,18 +209,9 @@ export function allSkillsToCsv(skillDirs: string[]): string {
 	for (const dir of skillDirs) {
 		const csv = skillsToCsv(dir);
 		if (csv) {
-			// Skip header, add data rows
-			const lines = csv.split("\n");
-			for (let i = 1; i < lines.length; i++) {
-				const line = lines[i].trim();
-				if (line) {
-					// Use proper CSV parser to handle quoted values and commas
-					const parsedRows = parseCSV(line);
-					// parseCSV returns array of rows, we just want the first (current) row
-					if (parsedRows.length > 0) {
-						allRows.push(parsedRows[0]);
-					}
-				}
+			const parsedRows = parseCSV(csv);
+			for (let i = 1; i < parsedRows.length; i++) {
+				allRows.push(parsedRows[i]);
 			}
 		}
 	}

--- a/cli/src/tasks/converter.ts
+++ b/cli/src/tasks/converter.ts
@@ -94,8 +94,8 @@ export function jsonToCsv(jsonContent: string): string {
 	let data: unknown;
 	try {
 		data = JSON.parse(jsonContent);
-	} catch {
-		return "id,title,done,group,desc\n";
+	} catch (err) {
+		throw new Error(`Invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
 	}
 	const tasks: JsonTask[] = Array.isArray(data)
 		? data

--- a/cli/src/tasks/csv.ts
+++ b/cli/src/tasks/csv.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { logWarn } from "../ui/logger.ts";
 import type { Task, TaskSource } from "./types.ts";
 
 /**
@@ -155,7 +156,7 @@ export class CsvTaskSource implements TaskSource {
 		const resolvedTitleIndex = titleIndex >= 0 ? titleIndex : 1;
 		const resolvedDoneIndex = doneIndex >= 0 ? doneIndex : 2;
 		if (doneIndex < 0) {
-			console.warn(
+			logWarn(
 				`CSV markComplete: no 'done'/'completed' header found for ${this.filePath}, falling back to column index 2.`,
 			);
 		}

--- a/cli/src/tasks/csv.ts
+++ b/cli/src/tasks/csv.ts
@@ -122,20 +122,6 @@ export class CsvTaskSource implements TaskSource {
 		return tasks;
 	}
 
-	private writeFile(tasks: CsvTask[]): void {
-		const rows: string[][] = [["id", "title", "done", "group", "desc"]];
-		for (const task of tasks) {
-			rows.push([
-				task.id,
-				task.title,
-				task.completed ? "1" : "0",
-				String(task.parallelGroup),
-				task.description,
-			]);
-		}
-		writeFileSync(this.filePath, rowsToCsv(rows), "utf-8");
-	}
-
 	async getAllTasks(): Promise<Task[]> {
 		const tasks = this.readFile();
 		return tasks
@@ -155,11 +141,37 @@ export class CsvTaskSource implements TaskSource {
 	}
 
 	async markComplete(id: string): Promise<void> {
-		const tasks = this.readFile();
-		const task = tasks.find((t) => t.id === id || t.title === id);
-		if (task) {
-			task.completed = true;
-			this.writeFile(tasks);
+		const content = readFileSync(this.filePath, "utf-8");
+		const rows = parseCSV(content);
+		if (rows.length < 2) {
+			return;
+		}
+
+		const header = rows[0].map((cell) => cell.trim().toLowerCase());
+		const idIndex = header.indexOf("id");
+		const titleIndex = header.indexOf("title");
+		const doneIndex = Math.max(header.indexOf("done"), header.indexOf("completed"));
+		const resolvedIdIndex = idIndex >= 0 ? idIndex : 0;
+		const resolvedTitleIndex = titleIndex >= 0 ? titleIndex : 1;
+		const resolvedDoneIndex = doneIndex >= 0 ? doneIndex : 2;
+
+		let updated = false;
+		for (let i = 1; i < rows.length; i++) {
+			const row = rows[i];
+			const rowId = row[resolvedIdIndex] || "";
+			const rowTitle = row[resolvedTitleIndex] || "";
+			if (rowId === id || rowTitle === id) {
+				while (row.length <= resolvedDoneIndex) {
+					row.push("");
+				}
+				row[resolvedDoneIndex] = "1";
+				updated = true;
+				break;
+			}
+		}
+
+		if (updated) {
+			writeFileSync(this.filePath, rowsToCsv(rows), "utf-8");
 		}
 	}
 

--- a/cli/src/tasks/csv.ts
+++ b/cli/src/tasks/csv.ts
@@ -1,0 +1,199 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import type { Task, TaskSource } from "./types.ts";
+
+/**
+ * Simple CSV parser - handles basic CSV format with proper escaping
+ */
+export function parseCSV(content: string): string[][] {
+	const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let current = "";
+	let inQuotes = false;
+
+	for (let i = 0; i < normalized.length; i++) {
+		const char = normalized[i];
+
+		if (char === '"') {
+			if (inQuotes && normalized[i + 1] === '"') {
+				current += '"';
+				i++;
+			} else {
+				inQuotes = !inQuotes;
+			}
+			continue;
+		}
+
+		if (char === "," && !inQuotes) {
+			row.push(current);
+			current = "";
+			continue;
+		}
+
+		if (char === "\n" && !inQuotes) {
+			row.push(current);
+			rows.push(row);
+			row = [];
+			current = "";
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current.length > 0 || row.length > 0) {
+		row.push(current);
+		rows.push(row);
+	}
+
+	return rows;
+}
+
+function sanitizeCsvCell(value: string): string {
+	if (/^[=+\-@]/.test(value)) {
+		return `'${value}`;
+	}
+	return value;
+}
+
+/**
+ * Escape a value for CSV output
+ * Handles commas, quotes, newlines, and carriage returns
+ */
+function escapeCSV(value: string): string {
+	// Defensive: ensure value is a string
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const strValue = String(value);
+	const safeValue = sanitizeCsvCell(strValue);
+	// Escape if contains special characters: comma, quote, newline, or carriage return
+	if (/[",\n\r]/.test(safeValue)) {
+		return `"${safeValue.replace(/"/g, '""')}"`;
+	}
+	return safeValue;
+}
+
+/**
+ * Convert rows to CSV string
+ */
+function toCSV(rows: string[][]): string {
+	return rows.map((row) => row.map(escapeCSV).join(",")).join("\n");
+}
+
+interface CsvTask {
+	id: string;
+	title: string;
+	completed: boolean;
+	parallelGroup: number;
+	description: string;
+}
+
+/**
+ * CSV task source - reads tasks from CSV files
+ * Format: id,title,completed,group,desc
+ */
+export class CsvTaskSource implements TaskSource {
+	type = "csv" as const;
+	private filePath: string;
+
+	constructor(filePath: string) {
+		this.filePath = filePath;
+	}
+
+	private readFile(): CsvTask[] {
+		const content = readFileSync(this.filePath, "utf-8");
+		const rows = parseCSV(content);
+
+		// Skip header row
+		const tasks: CsvTask[] = [];
+		for (let i = 1; i < rows.length; i++) {
+			const row = rows[i];
+			if (row.length >= 2) {
+				tasks.push({
+					id: row[0] || String(i),
+					title: row[1] || "",
+					completed: row[2] === "1" || row[2]?.toLowerCase() === "true",
+					parallelGroup: Number.parseInt(row[3] || "0", 10) || 0,
+					description: row[4] || "",
+				});
+			}
+		}
+		return tasks;
+	}
+
+	private writeFile(tasks: CsvTask[]): void {
+		const rows: string[][] = [["id", "title", "done", "group", "desc"]];
+		for (const task of tasks) {
+			rows.push([task.id, task.title, task.completed ? "1" : "0", String(task.parallelGroup), task.description]);
+		}
+		writeFileSync(this.filePath, toCSV(rows), "utf-8");
+	}
+
+	async getAllTasks(): Promise<Task[]> {
+		const tasks = this.readFile();
+		return tasks
+			.filter((t) => !t.completed)
+			.map((t) => ({
+				id: t.id,
+				title: t.title,
+				body: t.description || undefined,
+				parallelGroup: t.parallelGroup || undefined,
+				completed: false,
+			}));
+	}
+
+	async getNextTask(): Promise<Task | null> {
+		const tasks = await this.getAllTasks();
+		return tasks[0] || null;
+	}
+
+	async markComplete(id: string): Promise<void> {
+		const tasks = this.readFile();
+		const task = tasks.find((t) => t.id === id || t.title === id);
+		if (task) {
+			task.completed = true;
+			this.writeFile(tasks);
+		}
+	}
+
+	async countRemaining(): Promise<number> {
+		const tasks = this.readFile();
+		return tasks.filter((t) => !t.completed).length;
+	}
+
+	async countCompleted(): Promise<number> {
+		const tasks = this.readFile();
+		return tasks.filter((t) => t.completed).length;
+	}
+
+	/**
+	 * Get tasks in a specific parallel group
+	 */
+	async getTasksInGroup(group: number): Promise<Task[]> {
+		const tasks = this.readFile();
+		return tasks
+			.filter((t) => !t.completed && t.parallelGroup === group)
+			.map((t) => ({
+				id: t.id,
+				title: t.title,
+				body: t.description || undefined,
+				parallelGroup: t.parallelGroup || undefined,
+				completed: false,
+			}));
+	}
+}
+
+/**
+ * Convert tasks array to compact CSV string for prompts
+ */
+export function tasksToCompactCsv(tasks: Task[]): string {
+	if (tasks.length === 0) return "";
+
+	const rows: string[][] = [["#", "task", "grp"]];
+	for (let i = 0; i < tasks.length; i++) {
+		const t = tasks[i];
+		rows.push([String(i + 1), t.title, t.parallelGroup ? String(t.parallelGroup) : "0"]);
+	}
+	return toCSV(rows);
+}

--- a/cli/src/tasks/csv.ts
+++ b/cli/src/tasks/csv.ts
@@ -154,6 +154,11 @@ export class CsvTaskSource implements TaskSource {
 		const resolvedIdIndex = idIndex >= 0 ? idIndex : 0;
 		const resolvedTitleIndex = titleIndex >= 0 ? titleIndex : 1;
 		const resolvedDoneIndex = doneIndex >= 0 ? doneIndex : 2;
+		if (doneIndex < 0) {
+			console.warn(
+				`CSV markComplete: no 'done'/'completed' header found for ${this.filePath}, falling back to column index 2.`,
+			);
+		}
 
 		let updated = false;
 		for (let i = 1; i < rows.length; i++) {

--- a/cli/src/tasks/csv.ts
+++ b/cli/src/tasks/csv.ts
@@ -60,7 +60,7 @@ function sanitizeCsvCell(value: string): string {
  * Escape a value for CSV output
  * Handles commas, quotes, newlines, and carriage returns
  */
-function escapeCSV(value: string): string {
+export function escapeCsvValue(value: string): string {
 	// Defensive: ensure value is a string
 	if (value === null || value === undefined) {
 		return "";
@@ -77,8 +77,8 @@ function escapeCSV(value: string): string {
 /**
  * Convert rows to CSV string
  */
-function toCSV(rows: string[][]): string {
-	return rows.map((row) => row.map(escapeCSV).join(",")).join("\n");
+export function rowsToCsv(rows: string[][]): string {
+	return rows.map((row) => row.map(escapeCsvValue).join(",")).join("\n");
 }
 
 interface CsvTask {
@@ -125,9 +125,15 @@ export class CsvTaskSource implements TaskSource {
 	private writeFile(tasks: CsvTask[]): void {
 		const rows: string[][] = [["id", "title", "done", "group", "desc"]];
 		for (const task of tasks) {
-			rows.push([task.id, task.title, task.completed ? "1" : "0", String(task.parallelGroup), task.description]);
+			rows.push([
+				task.id,
+				task.title,
+				task.completed ? "1" : "0",
+				String(task.parallelGroup),
+				task.description,
+			]);
 		}
-		writeFileSync(this.filePath, toCSV(rows), "utf-8");
+		writeFileSync(this.filePath, rowsToCsv(rows), "utf-8");
 	}
 
 	async getAllTasks(): Promise<Task[]> {
@@ -195,5 +201,5 @@ export function tasksToCompactCsv(tasks: Task[]): string {
 		const t = tasks[i];
 		rows.push([String(i + 1), t.title, t.parallelGroup ? String(t.parallelGroup) : "0"]);
 	}
-	return toCSV(rows);
+	return rowsToCsv(rows);
 }

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -2,22 +2,24 @@ import { Octokit } from "@octokit/rest";
 import type { Task, TaskSource } from "./types.ts";
 
 /**
- * Cached GitHub issues data
+ * GitHub token patterns for validation
+ * Supports classic PATs (ghp_), fine-grained PATs (github_pat_), and OAuth tokens (gho_)
  */
-interface GitHubCache {
-	openIssues: Task[];
-	closedCount: number;
-	lastFetched: number;
-}
+const GITHUB_TOKEN_PATTERNS = [
+	/^ghp_[A-Za-z0-9]{36}$/, // Classic PAT
+	/^github_pat_[A-Za-z0-9_]{82}$/, // Fine-grained PAT
+	/^gho_[A-Za-z0-9]{52}$/, // OAuth token
+];
 
-/** Cache TTL in milliseconds (30 seconds) */
-const CACHE_TTL_MS = 30_000;
+/**
+ * Validate GitHub token format
+ */
+function validateGitHubToken(token: string): boolean {
+	return GITHUB_TOKEN_PATTERNS.some((pattern) => pattern.test(token));
+}
 
 /**
  * GitHub Issues task source - reads tasks from GitHub issues
- *
- * Performance optimized: caches issue data to avoid redundant API calls.
- * Cache is invalidated after TTL or when markComplete() is called.
  */
 export class GitHubTaskSource implements TaskSource {
 	type = "github" as const;
@@ -25,48 +27,38 @@ export class GitHubTaskSource implements TaskSource {
 	private owner: string;
 	private repo: string;
 	private label?: string;
-	private cache: GitHubCache | null = null;
 
 	constructor(repoPath: string, label?: string) {
 		// Parse owner/repo format
-		const [owner, repo] = repoPath.split("/");
-		if (!owner || !repo) {
+		const parts = repoPath.split("/").filter(Boolean);
+		if (parts.length !== 2) {
 			throw new Error(`Invalid repo format: ${repoPath}. Expected owner/repo`);
 		}
+		const [owner, repo] = parts;
 
 		this.owner = owner;
 		this.repo = repo;
 		this.label = label;
 
 		// Use GITHUB_TOKEN from environment
+		const token = process.env.GITHUB_TOKEN;
+
+		if (!token) {
+			throw new Error("GITHUB_TOKEN environment variable is not set");
+		}
+
+		if (!validateGitHubToken(token)) {
+			throw new Error(
+				"GITHUB_TOKEN has invalid format. Expected: ghp_***, github_pat_***, or gho_***",
+			);
+		}
+
 		this.octokit = new Octokit({
-			auth: process.env.GITHUB_TOKEN,
+			auth: token,
 		});
 	}
 
-	/**
-	 * Check if cache is still valid
-	 */
-	private isCacheValid(): boolean {
-		if (!this.cache) return false;
-		return Date.now() - this.cache.lastFetched < CACHE_TTL_MS;
-	}
-
-	/**
-	 * Invalidate the cache
-	 */
-	private invalidateCache(): void {
-		this.cache = null;
-	}
-
-	/**
-	 * Fetch and cache open issues
-	 */
-	private async fetchOpenIssues(): Promise<Task[]> {
-		if (this.isCacheValid() && this.cache) {
-			return this.cache.openIssues;
-		}
-
+	async getAllTasks(): Promise<Task[]> {
 		const issues = await this.octokit.paginate(this.octokit.issues.listForRepo, {
 			owner: this.owner,
 			repo: this.repo,
@@ -75,29 +67,16 @@ export class GitHubTaskSource implements TaskSource {
 			per_page: 100,
 		});
 
-		const tasks = issues.map((issue) => ({
+		return issues.map((issue) => ({
 			id: `${issue.number}:${issue.title}`,
 			title: issue.title,
 			body: issue.body || undefined,
 			completed: false,
 		}));
-
-		// Update cache (preserve closed count if we have it)
-		this.cache = {
-			openIssues: tasks,
-			closedCount: this.cache?.closedCount ?? -1,
-			lastFetched: Date.now(),
-		};
-
-		return tasks;
-	}
-
-	async getAllTasks(): Promise<Task[]> {
-		return await this.fetchOpenIssues();
 	}
 
 	async getNextTask(): Promise<Task | null> {
-		const tasks = await this.fetchOpenIssues();
+		const tasks = await this.getAllTasks();
 		return tasks[0] || null;
 	}
 
@@ -115,22 +94,21 @@ export class GitHubTaskSource implements TaskSource {
 			issue_number: issueNumber,
 			state: "closed",
 		});
-
-		// Invalidate cache after modification
-		this.invalidateCache();
 	}
 
 	async countRemaining(): Promise<number> {
-		const tasks = await this.fetchOpenIssues();
-		return tasks.length;
+		const issues = await this.octokit.paginate(this.octokit.issues.listForRepo, {
+			owner: this.owner,
+			repo: this.repo,
+			state: "open",
+			labels: this.label,
+			per_page: 100,
+		});
+
+		return issues.length;
 	}
 
 	async countCompleted(): Promise<number> {
-		// Check if we have a recent closed count
-		if (this.isCacheValid() && this.cache && this.cache.closedCount >= 0) {
-			return this.cache.closedCount;
-		}
-
 		const issues = await this.octokit.paginate(this.octokit.issues.listForRepo, {
 			owner: this.owner,
 			repo: this.repo,
@@ -139,14 +117,7 @@ export class GitHubTaskSource implements TaskSource {
 			per_page: 100,
 		});
 
-		const closedCount = issues.length;
-
-		// Update cache with closed count
-		if (this.cache) {
-			this.cache.closedCount = closedCount;
-		}
-
-		return closedCount;
+		return issues.length;
 	}
 
 	/**

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -9,6 +9,7 @@ const GITHUB_TOKEN_PATTERNS = [
 	/^ghp_[A-Za-z0-9]{36}$/, // Classic PAT
 	/^github_pat_[A-Za-z0-9_]{82}$/, // Fine-grained PAT
 	/^gho_[A-Za-z0-9]{52}$/, // OAuth token
+	/^ghs_[A-Za-z0-9]{36}$/, // GitHub App installation token
 ];
 
 /**
@@ -49,7 +50,7 @@ export class GitHubTaskSource implements TaskSource {
 
 		if (!validateGitHubToken(token)) {
 			throw new Error(
-				"GITHUB_TOKEN has invalid format. Expected: ghp_***, github_pat_***, or gho_***",
+				"GITHUB_TOKEN has invalid format. Expected: ghp_***, github_pat_***, gho_***, or ghs_***",
 			);
 		}
 

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -3,7 +3,8 @@ import type { Task, TaskSource } from "./types.ts";
 
 /**
  * GitHub token patterns for validation
- * Supports classic PATs (ghp_), fine-grained PATs (github_pat_), and OAuth tokens (gho_)
+ * Supports classic PATs (ghp_), fine-grained PATs (github_pat_), OAuth tokens (gho_),
+ * and GitHub App installation tokens (ghs_).
  */
 const GITHUB_TOKEN_PATTERNS = [
 	/^ghp_[A-Za-z0-9]{36}$/, // Classic PAT
@@ -12,16 +13,10 @@ const GITHUB_TOKEN_PATTERNS = [
 	/^ghs_[A-Za-z0-9]{36}$/, // GitHub App installation token
 ];
 
-/**
- * Validate GitHub token format
- */
 function validateGitHubToken(token: string): boolean {
 	return GITHUB_TOKEN_PATTERNS.some((pattern) => pattern.test(token));
 }
 
-/**
- * GitHub Issues task source - reads tasks from GitHub issues
- */
 export class GitHubTaskSource implements TaskSource {
 	type = "github" as const;
 	private octokit: Octokit;
@@ -30,7 +25,6 @@ export class GitHubTaskSource implements TaskSource {
 	private label?: string;
 
 	constructor(repoPath: string, label?: string) {
-		// Parse owner/repo format
 		const parts = repoPath.split("/").filter(Boolean);
 		if (parts.length !== 2) {
 			throw new Error(`Invalid repo format: ${repoPath}. Expected owner/repo`);
@@ -41,9 +35,7 @@ export class GitHubTaskSource implements TaskSource {
 		this.repo = repo;
 		this.label = label;
 
-		// Use GITHUB_TOKEN from environment
 		const token = process.env.GITHUB_TOKEN;
-
 		if (!token) {
 			throw new Error("GITHUB_TOKEN environment variable is not set");
 		}
@@ -54,9 +46,7 @@ export class GitHubTaskSource implements TaskSource {
 			);
 		}
 
-		this.octokit = new Octokit({
-			auth: token,
-		});
+		this.octokit = new Octokit({ auth: token });
 	}
 
 	async getAllTasks(): Promise<Task[]> {
@@ -82,9 +72,7 @@ export class GitHubTaskSource implements TaskSource {
 	}
 
 	async markComplete(id: string): Promise<void> {
-		// Extract issue number from "number:title" format
 		const issueNumber = Number.parseInt(id.split(":")[0], 10);
-
 		if (Number.isNaN(issueNumber)) {
 			throw new Error(`Invalid issue ID: ${id}`);
 		}
@@ -121,12 +109,8 @@ export class GitHubTaskSource implements TaskSource {
 		return issues.length;
 	}
 
-	/**
-	 * Get full issue body for a task
-	 */
 	async getIssueBody(id: string): Promise<string> {
 		const issueNumber = Number.parseInt(id.split(":")[0], 10);
-
 		if (Number.isNaN(issueNumber)) {
 			return "";
 		}

--- a/cli/src/tasks/index.ts
+++ b/cli/src/tasks/index.ts
@@ -2,6 +2,7 @@ export * from "./cached-task-source.ts";
 export * from "./converter.ts";
 export * from "./csv.ts";
 export * from "./github.ts";
+export * from "./json.ts";
 export * from "./markdown.ts";
 export * from "./markdown-folder.ts";
 export * from "./types.ts";
@@ -9,6 +10,7 @@ export * from "./yaml.ts";
 
 import { CsvTaskSource } from "./csv.ts";
 import { GitHubTaskSource } from "./github.ts";
+import { JsonTaskSource } from "./json.ts";
 import { MarkdownFolderTaskSource } from "./markdown-folder.ts";
 import { MarkdownTaskSource } from "./markdown.ts";
 import type { TaskSource, TaskSourceType } from "./types.ts";
@@ -52,6 +54,12 @@ export function createTaskSource(options: TaskSourceOptions): TaskSource {
 				throw new Error("filePath is required for csv task source");
 			}
 			return new CsvTaskSource(options.filePath);
+
+		case "json":
+			if (!options.filePath) {
+				throw new Error("filePath is required for json task source");
+			}
+			return new JsonTaskSource(options.filePath);
 
 		case "github":
 			if (!options.repo) {

--- a/cli/src/tasks/index.ts
+++ b/cli/src/tasks/index.ts
@@ -1,13 +1,14 @@
-export * from "./types.ts";
+export * from "./cached-task-source.ts";
+export * from "./converter.ts";
+export * from "./csv.ts";
+export * from "./github.ts";
 export * from "./markdown.ts";
 export * from "./markdown-folder.ts";
+export * from "./types.ts";
 export * from "./yaml.ts";
-export * from "./json.ts";
-export * from "./github.ts";
-export * from "./cached-task-source.ts";
 
+import { CsvTaskSource } from "./csv.ts";
 import { GitHubTaskSource } from "./github.ts";
-import { JsonTaskSource } from "./json.ts";
 import { MarkdownFolderTaskSource } from "./markdown-folder.ts";
 import { MarkdownTaskSource } from "./markdown.ts";
 import type { TaskSource, TaskSourceType } from "./types.ts";
@@ -15,7 +16,7 @@ import { YamlTaskSource } from "./yaml.ts";
 
 interface TaskSourceOptions {
 	type: TaskSourceType;
-	/** File path for markdown/yaml sources */
+	/** File path for markdown/yaml/csv sources */
 	filePath?: string;
 	/** Repo path (owner/repo) for GitHub source */
 	repo?: string;
@@ -46,11 +47,11 @@ export function createTaskSource(options: TaskSourceOptions): TaskSource {
 			}
 			return new YamlTaskSource(options.filePath);
 
-		case "json":
+		case "csv":
 			if (!options.filePath) {
-				throw new Error("filePath is required for json task source");
+				throw new Error("filePath is required for csv task source");
 			}
-			return new JsonTaskSource(options.filePath);
+			return new CsvTaskSource(options.filePath);
 
 		case "github":
 			if (!options.repo) {

--- a/cli/src/tasks/markdown-folder.ts
+++ b/cli/src/tasks/markdown-folder.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
 import type { Task, TaskSource } from "./types.ts";
 
 /**
@@ -10,39 +10,13 @@ function readFileNormalized(filePath: string): string {
 }
 
 /**
- * Cached data for a single markdown file
- */
-interface FileCacheEntry {
-	content: string;
-	lines: string[];
-	incompleteTasks: Task[];
-	remainingCount: number;
-	completedCount: number;
-}
-
-/**
- * Cached data for the entire folder
- */
-interface FolderCache {
-	files: Map<string, FileCacheEntry>;
-	fileMtimes: Map<string, number>;
-	allTasks: Task[];
-	totalRemaining: number;
-	totalCompleted: number;
-}
-
-/**
  * Markdown folder task source - reads tasks from multiple markdown files in a folder
  * Each task ID includes the source file for proper tracking: "filename.md:lineNumber"
- *
- * Performance optimized: caches all file contents and task counts to avoid
- * redundant file reads across getAllTasks(), countRemaining(), and countCompleted().
  */
 export class MarkdownFolderTaskSource implements TaskSource {
 	type = "markdown-folder" as const;
 	private folderPath: string;
 	private markdownFiles: string[] = [];
-	private cache: FolderCache | null = null;
 
 	constructor(folderPath: string) {
 		this.folderPath = folderPath;
@@ -82,8 +56,22 @@ export class MarkdownFolderTaskSource implements TaskSource {
 			throw new Error(`Invalid task ID format: ${id}`);
 		}
 		const fileName = id.substring(0, lastColon);
+		if (fileName !== basename(fileName) || !fileName.endsWith(".md")) {
+			throw new Error(`Invalid task file in task ID: ${id}`);
+		}
 		const lineNumber = Number.parseInt(id.substring(lastColon + 1), 10);
+		if (!Number.isFinite(lineNumber) || lineNumber <= 0) {
+			throw new Error(`Invalid task line number in task ID: ${id}`);
+		}
 		const filePath = join(this.folderPath, fileName);
+		const baseResolved = resolve(this.folderPath);
+		const fileResolved = resolve(filePath);
+		if (
+			fileResolved !== baseResolved &&
+			!fileResolved.startsWith(`${baseResolved}${sep}`)
+		) {
+			throw new Error(`Task ID path escapes markdown folder: ${id}`);
+		}
 		return { filePath, lineNumber };
 	}
 
@@ -95,34 +83,12 @@ export class MarkdownFolderTaskSource implements TaskSource {
 		return `${fileName}:${lineNumber}`;
 	}
 
-	/**
-	 * Get a file's modification time
-	 */
-	private getFileMtime(filePath: string): number {
-		try {
-			return statSync(filePath).mtimeMs;
-		} catch {
-			return 0;
-		}
-	}
-
-	/**
-	 * Load and cache all file contents with parsed task data
-	 */
-	private loadCache(): FolderCache {
-		const files = new Map<string, FileCacheEntry>();
-		const fileMtimes = new Map<string, number>();
+	async getAllTasks(): Promise<Task[]> {
 		const allTasks: Task[] = [];
-		let totalRemaining = 0;
-		let totalCompleted = 0;
 
 		for (const filePath of this.markdownFiles) {
-			fileMtimes.set(filePath, this.getFileMtime(filePath));
 			const content = readFileNormalized(filePath);
 			const lines = content.split("\n");
-			const incompleteTasks: Task[] = [];
-			let remainingCount = 0;
-			let completedCount = 0;
 
 			for (let i = 0; i < lines.length; i++) {
 				const line = lines[i];
@@ -130,88 +96,25 @@ export class MarkdownFolderTaskSource implements TaskSource {
 				// Match incomplete tasks
 				const incompleteMatch = line.match(/^- \[ \] (.+)$/);
 				if (incompleteMatch) {
-					const task = {
+					allTasks.push({
 						id: this.createTaskId(filePath, i + 1),
 						title: incompleteMatch[1].trim(),
 						completed: false,
-					};
-					incompleteTasks.push(task);
-					allTasks.push(task);
-					remainingCount++;
-				}
-
-				// Match completed tasks
-				if (/^- \[x\] /i.test(line)) {
-					completedCount++;
+					});
 				}
 			}
-
-			files.set(filePath, {
-				content,
-				lines,
-				incompleteTasks,
-				remainingCount,
-				completedCount,
-			});
-
-			totalRemaining += remainingCount;
-			totalCompleted += completedCount;
 		}
 
-		this.cache = {
-			files,
-			fileMtimes,
-			allTasks,
-			totalRemaining,
-			totalCompleted,
-		};
-
-		return this.cache;
-	}
-
-	/**
-	 * Check if any cached file has been modified externally
-	 */
-	private isCacheStale(): boolean {
-		if (!this.cache) return true;
-		for (const [filePath, cachedMtime] of this.cache.fileMtimes) {
-			if (this.getFileMtime(filePath) !== cachedMtime) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Get cached content or load fresh if any file was modified externally
-	 */
-	private getCache(): FolderCache {
-		if (!this.cache || this.isCacheStale()) {
-			return this.loadCache();
-		}
-		return this.cache;
-	}
-
-	/**
-	 * Invalidate cache (call after file modifications)
-	 */
-	private invalidateCache(): void {
-		this.cache = null;
-	}
-
-	async getAllTasks(): Promise<Task[]> {
-		return [...this.getCache().allTasks];
+		return allTasks;
 	}
 
 	async getNextTask(): Promise<Task | null> {
-		const cache = this.getCache();
-		return cache.allTasks[0] || null;
+		const tasks = await this.getAllTasks();
+		return tasks[0] || null;
 	}
 
 	async markComplete(id: string): Promise<void> {
 		const { filePath, lineNumber } = this.parseTaskId(id);
-		// Force fresh read for modification to avoid stale data
-		this.invalidateCache();
 		const content = readFileNormalized(filePath);
 		const lines = content.split("\n");
 		const lineIndex = lineNumber - 1;
@@ -220,17 +123,31 @@ export class MarkdownFolderTaskSource implements TaskSource {
 			// Replace "- [ ]" with "- [x]"
 			lines[lineIndex] = lines[lineIndex].replace(/^- \[ \] /, "- [x] ");
 			writeFileSync(filePath, lines.join("\n"), "utf-8");
-			// Invalidate cache after modification
-			this.invalidateCache();
 		}
 	}
 
 	async countRemaining(): Promise<number> {
-		return this.getCache().totalRemaining;
+		let count = 0;
+
+		for (const filePath of this.markdownFiles) {
+			const content = readFileNormalized(filePath);
+			const matches = content.match(/^- \[ \] /gm);
+			count += matches?.length || 0;
+		}
+
+		return count;
 	}
 
 	async countCompleted(): Promise<number> {
-		return this.getCache().totalCompleted;
+		let count = 0;
+
+		for (const filePath of this.markdownFiles) {
+			const content = readFileNormalized(filePath);
+			const matches = content.match(/^- \[x\] /gim);
+			count += matches?.length || 0;
+		}
+
+		return count;
 	}
 
 	/**

--- a/cli/src/tasks/markdown.ts
+++ b/cli/src/tasks/markdown.ts
@@ -130,9 +130,15 @@ export class MarkdownTaskSource implements TaskSource {
 		if (lineNumber >= 0 && lineNumber < lines.length) {
 			// Replace "- [ ]" with "- [x]"
 			lines[lineNumber] = lines[lineNumber].replace(/^- \[ \] /, "- [x] ");
-			writeFileSync(this.filePath, lines.join("\n"), "utf-8");
+			try {
+				writeFileSync(this.filePath, lines.join("\n"), "utf-8");
+			} catch (error) {
+				throw new Error(`Failed to write file: ${error instanceof Error ? error.message : error}`);
+			}
 			// Invalidate cache after modification
 			this.invalidateCache();
+		} else {
+			throw new Error(`Invalid task ID: ${id}`);
 		}
 	}
 

--- a/cli/src/tasks/types.ts
+++ b/cli/src/tasks/types.ts
@@ -17,7 +17,7 @@ export interface Task {
 /**
  * Task source type
  */
-export type TaskSourceType = "markdown" | "markdown-folder" | "yaml" | "json" | "github";
+export type TaskSourceType = "markdown" | "markdown-folder" | "yaml" | "json" | "csv" | "github";
 
 /**
  * Task source interface - one per format

--- a/cli/src/tasks/yaml.ts
+++ b/cli/src/tasks/yaml.ts
@@ -22,10 +22,11 @@ export function hasPrototypePollution(obj: unknown): boolean {
 
 	const visited = new Set<unknown>();
 	const queue: Array<{ value: unknown; depth: number }> = [{ value: obj, depth: 0 }];
+	let head = 0;
 	let nodesVisited = 0;
 
-	while (queue.length > 0) {
-		const current = queue.shift();
+	while (head < queue.length) {
+		const current = queue[head++];
 		if (!current) continue;
 
 		nodesVisited++;

--- a/cli/src/tasks/yaml.ts
+++ b/cli/src/tasks/yaml.ts
@@ -13,10 +13,10 @@ interface YamlTaskFile {
 	tasks: YamlTask[];
 }
 
-function hasPrototypePollution(obj: unknown): boolean {
+export function hasPrototypePollution(obj: unknown): boolean {
 	const MAX_DEPTH = 20;
 	const MAX_NODES = 10000;
-	const dangerousKeys = new Set(["__proto__", "constructor", "prototype"]);
+	const dangerousKeys = new Set(["__proto__"]);
 
 	if (typeof obj !== "object" || obj === null) return false;
 

--- a/cli/src/tasks/yaml.ts
+++ b/cli/src/tasks/yaml.ts
@@ -13,6 +13,49 @@ interface YamlTaskFile {
 	tasks: YamlTask[];
 }
 
+function hasPrototypePollution(obj: unknown): boolean {
+	const MAX_DEPTH = 20;
+	const MAX_NODES = 10000;
+	const dangerousKeys = new Set(["__proto__", "constructor", "prototype"]);
+
+	if (typeof obj !== "object" || obj === null) return false;
+
+	const visited = new Set<unknown>();
+	const queue: Array<{ value: unknown; depth: number }> = [{ value: obj, depth: 0 }];
+	let nodesVisited = 0;
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current) continue;
+
+		nodesVisited++;
+		if (nodesVisited > MAX_NODES) {
+			throw new Error("YAML file too complex to validate safely");
+		}
+
+		if (current.depth > MAX_DEPTH) {
+			throw new Error("YAML file nesting exceeds safety limits");
+		}
+
+		if (typeof current.value !== "object" || current.value === null) {
+			continue;
+		}
+
+		if (visited.has(current.value)) {
+			continue;
+		}
+		visited.add(current.value);
+
+		for (const key of Object.keys(current.value)) {
+			if (dangerousKeys.has(key)) return true;
+			const value = (current.value as Record<string, unknown>)[key];
+			queue.push({ value, depth: current.depth + 1 });
+		}
+	}
+
+	return false;
+}
+
 /**
  * YAML task source - reads tasks from YAML files
  * Format:
@@ -30,19 +73,37 @@ export class YamlTaskSource implements TaskSource {
 	}
 
 	private readFile(): YamlTaskFile {
-		const content = readFileSync(this.filePath, "utf-8");
-		return YAML.parse(content) as YamlTaskFile;
+		try {
+			const content = readFileSync(this.filePath, "utf-8");
+			const parsed = YAML.parse(content) as YamlTaskFile;
+
+			if (hasPrototypePollution(parsed)) {
+				throw new Error("YAML file contains potentially malicious prototype pollution keys");
+			}
+
+			return parsed;
+		} catch (error) {
+			throw new Error(
+				`Failed to read/parse YAML file: ${error instanceof Error ? error.message : error}`,
+			);
+		}
 	}
 
 	private writeFile(data: YamlTaskFile): void {
-		writeFileSync(this.filePath, YAML.stringify(data), "utf-8");
+		try {
+			writeFileSync(this.filePath, YAML.stringify(data), "utf-8");
+		} catch (error) {
+			throw new Error(
+				`Failed to write YAML file: ${error instanceof Error ? error.message : error}`,
+			);
+		}
 	}
 
 	async getAllTasks(): Promise<Task[]> {
 		const data = this.readFile();
 		return (data.tasks || [])
 			.filter((t) => !t.completed)
-			.map((t, i) => ({
+			.map((t, _i) => ({
 				id: t.title, // Use title as ID for YAML tasks
 				title: t.title,
 				body: t.description,

--- a/cli/src/telemetry/collector.ts
+++ b/cli/src/telemetry/collector.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { sanitizeSecrets } from "../utils/sanitization.ts";
 import type {
 	Session,
 	SessionFull,
@@ -27,6 +28,26 @@ function getCliVersion(): string {
 		cachedVersion = "0.0.0";
 	}
 	return cachedVersion;
+}
+
+function sanitizeTelemetryValue(value: unknown): unknown {
+	if (typeof value === "string") {
+		return sanitizeSecrets(value);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeTelemetryValue(item));
+	}
+
+	if (value && typeof value === "object") {
+		const sanitized: Record<string, unknown> = {};
+		for (const [key, nested] of Object.entries(value)) {
+			sanitized[key] = sanitizeTelemetryValue(nested);
+		}
+		return sanitized;
+	}
+
+	return value;
 }
 
 /**
@@ -116,8 +137,8 @@ export class TelemetryCollector {
 
 		// Store prompts/responses for full mode
 		if (this.level === "full") {
-			if (prompt) this.prompts.push(prompt);
-			if (response) this.responses.push(response);
+			if (prompt) this.prompts.push(sanitizeSecrets(prompt));
+			if (response) this.responses.push(sanitizeSecrets(response));
 		}
 	}
 
@@ -131,7 +152,10 @@ export class TelemetryCollector {
 			startTime: Date.now(),
 			toolName,
 			parameterKeys: parameters ? Object.keys(parameters) : undefined,
-			parameters: this.level === "full" ? parameters : undefined,
+			parameters:
+				this.level === "full"
+					? (sanitizeTelemetryValue(parameters) as Record<string, unknown> | undefined)
+					: undefined,
 		};
 
 		// Track file paths in full mode
@@ -164,7 +188,7 @@ export class TelemetryCollector {
 		// Add full mode data
 		if (this.level === "full") {
 			toolCall.parameters = this.activeToolCall.parameters;
-			if (result) toolCall.result = result;
+			if (result) toolCall.result = sanitizeSecrets(result);
 		}
 
 		this.toolCalls.push(toolCall);
@@ -199,8 +223,10 @@ export class TelemetryCollector {
 		};
 
 		if (this.level === "full") {
-			toolCall.parameters = options?.parameters;
-			toolCall.result = options?.result;
+			toolCall.parameters = sanitizeTelemetryValue(options?.parameters) as
+				| Record<string, unknown>
+				| undefined;
+			toolCall.result = options?.result ? sanitizeSecrets(options.result) : undefined;
 
 			// Track file paths
 			if (options?.parameters) {
@@ -303,7 +329,7 @@ export class TelemetryCollector {
 				fullSession.response = this.responses.join("\n\n---\n\n");
 			}
 			if (this.filePaths.size > 0) {
-				fullSession.filePaths = Array.from(this.filePaths);
+				fullSession.filePaths = Array.from(this.filePaths).map((path) => sanitizeSecrets(path));
 			}
 			return { session: fullSession, toolCalls: this.toolCalls };
 		}

--- a/cli/src/telemetry/exporter.ts
+++ b/cli/src/telemetry/exporter.ts
@@ -161,7 +161,7 @@ export class TelemetryExporter {
 
 		await this.ensureExportsDir();
 		const filePath = outputPath || join(this.exportsDir, "openai-evals.jsonl");
-		await writeFile(filePath, entries.join("\n") + "\n", "utf-8");
+		await writeFile(filePath, `${entries.join("\n")}\n`, "utf-8");
 
 		return filePath;
 	}
@@ -194,7 +194,7 @@ export class TelemetryExporter {
 
 		await this.ensureExportsDir();
 		const filePath = outputPath || join(this.exportsDir, "raw-telemetry.jsonl");
-		const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+		const lines = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
 		await writeFile(filePath, lines, "utf-8");
 
 		return filePath;

--- a/cli/src/telemetry/types.ts
+++ b/cli/src/telemetry/types.ts
@@ -81,7 +81,7 @@ export type TelemetryLevel = "anonymous" | "full";
 /**
  * Full session data for webhook
  */
-interface WebhookSessionData {
+export interface WebhookSessionData {
 	sessionId: string;
 	engine: string;
 	mode: string;
@@ -106,7 +106,7 @@ interface WebhookSessionData {
 /**
  * Full session details for webhook (full privacy mode)
  */
-interface WebhookSessionDetails {
+export interface WebhookSessionDetails {
 	prompt?: string;
 	response?: string;
 	filePaths?: string[];

--- a/cli/src/telemetry/types.ts
+++ b/cli/src/telemetry/types.ts
@@ -79,6 +79,51 @@ export interface ToolCall {
 export type TelemetryLevel = "anonymous" | "full";
 
 /**
+ * Full session data for webhook
+ */
+interface WebhookSessionData {
+	sessionId: string;
+	engine: string;
+	mode: string;
+	cliVersion: string;
+	platform: string;
+	totalTokensIn: number;
+	totalTokensOut: number;
+	totalDurationMs: number;
+	taskCount: number;
+	successCount: number;
+	failedCount: number;
+	toolCalls: {
+		toolName: string;
+		callCount: number;
+		successCount: number;
+		failedCount: number;
+		avgDurationMs: number;
+	}[];
+	tags?: string[];
+}
+
+/**
+ * Full session details for webhook (full privacy mode)
+ */
+interface WebhookSessionDetails {
+	prompt?: string;
+	response?: string;
+	filePaths?: string[];
+}
+
+/**
+ * Telemetry webhook payload
+ */
+export interface TelemetryWebhookPayload {
+	event: string;
+	version: string;
+	timestamp: string;
+	session: WebhookSessionData;
+	details?: WebhookSessionDetails;
+}
+
+/**
  * Telemetry configuration
  */
 export interface TelemetryConfig {

--- a/cli/src/telemetry/webhook.ts
+++ b/cli/src/telemetry/webhook.ts
@@ -76,11 +76,10 @@ export async function sendTelemetryWebhook(
 	}
 
 	const payload = buildPayload(session, level);
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
 	try {
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-
 		const response = await fetch(webhookUrl, {
 			method: "POST",
 			headers: {
@@ -90,14 +89,19 @@ export async function sendTelemetryWebhook(
 			signal: controller.signal,
 		});
 
-		clearTimeout(timeoutId);
-
 		if (!response.ok) {
 			const text = await response.text().catch(() => "");
 			throw new Error(`HTTP ${response.status}${text ? `: ${text}` : ""}`);
 		}
 
-		logDebug(`Telemetry webhook sent successfully to ${webhookUrl}`);
+		const safeTarget = (() => {
+			try {
+				return new URL(webhookUrl).host;
+			} catch {
+				return "configured endpoint";
+			}
+		})();
+		logDebug(`Telemetry webhook sent successfully to ${safeTarget}`);
 	} catch (error) {
 		if (error instanceof Error && error.name === "AbortError") {
 			logError("Telemetry webhook timed out after 10 seconds");
@@ -107,5 +111,7 @@ export async function sendTelemetryWebhook(
 			);
 		}
 		// Don't throw - webhook failures shouldn't break the session
+	} finally {
+		clearTimeout(timeoutId);
 	}
 }

--- a/cli/src/telemetry/writer.ts
+++ b/cli/src/telemetry/writer.ts
@@ -57,7 +57,7 @@ export class TelemetryWriter {
 	async writeSession(session: Session | SessionFull): Promise<void> {
 		await this.ensureDir();
 		const path = join(this.outputDir, SESSIONS_FILE);
-		const line = JSON.stringify(session) + "\n";
+		const line = `${JSON.stringify(session)}\n`;
 		await appendFile(path, line, "utf-8");
 	}
 
@@ -69,7 +69,7 @@ export class TelemetryWriter {
 
 		await this.ensureDir();
 		const path = join(this.outputDir, TOOL_CALLS_FILE);
-		const lines = toolCalls.map((call) => JSON.stringify(call)).join("\n") + "\n";
+		const lines = `${toolCalls.map((call) => JSON.stringify(call)).join("\n")}\n`;
 		await appendFile(path, lines, "utf-8");
 	}
 

--- a/cli/src/telemetry/writer.ts
+++ b/cli/src/telemetry/writer.ts
@@ -7,6 +7,7 @@
 import { existsSync } from "node:fs";
 import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { logDebug } from "../ui/logger.ts";
 import type { Session, SessionFull, ToolCall } from "./types.js";
 
 const DEFAULT_OUTPUT_DIR = ".ralphy/telemetry";
@@ -91,8 +92,16 @@ export class TelemetryWriter {
 
 		const content = await readFile(path, "utf-8");
 		const lines = content.trim().split("\n").filter(Boolean);
+		const sessions: Array<Session | SessionFull> = [];
+		for (const line of lines) {
+			try {
+				sessions.push(JSON.parse(line) as Session | SessionFull);
+			} catch (error) {
+				logDebug(`Skipping invalid telemetry session line: ${error}`);
+			}
+		}
 
-		return lines.map((line) => JSON.parse(line) as Session | SessionFull);
+		return sessions;
 	}
 
 	/**
@@ -107,8 +116,16 @@ export class TelemetryWriter {
 
 		const content = await readFile(path, "utf-8");
 		const lines = content.trim().split("\n").filter(Boolean);
+		const toolCalls: ToolCall[] = [];
+		for (const line of lines) {
+			try {
+				toolCalls.push(JSON.parse(line) as ToolCall);
+			} catch (error) {
+				logDebug(`Skipping invalid telemetry tool-call line: ${error}`);
+			}
+		}
 
-		return lines.map((line) => JSON.parse(line) as ToolCall);
+		return toolCalls;
 	}
 
 	/**

--- a/cli/src/ui/logger.ts
+++ b/cli/src/ui/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 import { sanitizeSecrets } from "../utils/sanitization.ts";
@@ -9,22 +9,19 @@ const loggerState = {
 	debugMode: false,
 };
 
-// Allowed log directory - logs can only be written here
-const ALLOWED_LOG_DIR = "logs";
-
 /**
  * Validate log file path to prevent path traversal attacks
  */
 function validateLogPath(filePath: string): string {
-	const resolved = path.resolve(filePath);
-	const allowedDir = path.resolve(process.cwd(), ALLOWED_LOG_DIR);
-	const relative = path.relative(allowedDir, resolved);
-
-	if (relative.startsWith("..") || path.isAbsolute(relative)) {
-		throw new Error(`Invalid log file path: ${filePath} must be within ${ALLOWED_LOG_DIR}`);
+	if (!filePath || typeof filePath !== "string") {
+		throw new Error("Invalid log file path");
 	}
-
-	return resolved;
+	if (filePath.includes("\0")) {
+		throw new Error("Invalid log file path: null byte detected");
+	}
+	return path.isAbsolute(filePath)
+		? path.normalize(filePath)
+		: path.resolve(process.cwd(), filePath);
 }
 
 /**
@@ -103,30 +100,28 @@ class ConsoleLogSink implements LogSink {
 			console.error("[Logger] Invalid log entry");
 			return;
 		}
-		const timestamp = entry.timestamp ?? new Date().toISOString();
 		const level = entry.level ?? "info";
-		const component = entry.component ?? "ralphy";
 		const message = entry.message ?? "";
-		const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
+		const prefix = `[${level.toUpperCase()}]`;
 
 		switch (level) {
 			case "error":
-				console.error(pc.red(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				console.error(pc.red(`${prefix} ${message}`));
 				break;
 			case "warn":
-				console.warn(pc.yellow(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				console.warn(pc.yellow(`${prefix} ${message}`));
 				break;
 			case "success":
-				console.log(pc.green(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				console.log(pc.green(`${prefix} ${message}`));
 				break;
 			case "info":
-				console.log(pc.blue(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				console.log(pc.blue(`${prefix} ${message}`));
 				break;
 			case "debug":
-				console.log(pc.gray(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				console.log(pc.gray(`${prefix} ${message}`));
 				break;
 			default:
-				console.log(`${prefix} ${component ? `[${component}] ` : ""}${message}`);
+				console.log(`${prefix} ${message}`);
 		}
 	}
 }
@@ -264,6 +259,7 @@ export class JsonFileLogSink implements LogSink {
 	constructor(filePath: string, options?: { flushIntervalMs?: number; maxBufferSize?: number }) {
 		// Validate path to prevent path traversal attacks
 		this.filePath = validateLogPath(filePath);
+		mkdirSync(path.dirname(this.filePath), { recursive: true });
 		this.flushInterval = options?.flushIntervalMs ?? 1000;
 		this.maxBufferSize = options?.maxBufferSize ?? 100;
 

--- a/cli/src/ui/logger.ts
+++ b/cli/src/ui/logger.ts
@@ -1,49 +1,407 @@
+import { appendFileSync } from "node:fs";
+import path from "node:path";
 import pc from "picocolors";
+import { sanitizeSecrets } from "../utils/sanitization.ts";
 
-let verboseMode = false;
+// Use a module-level object for state to avoid direct mutable exports
+const loggerState = {
+	verboseMode: false,
+	debugMode: false,
+};
+
+// Allowed log directory - logs can only be written here
+const ALLOWED_LOG_DIR = "logs";
+
+/**
+ * Validate log file path to prevent path traversal attacks
+ */
+function validateLogPath(filePath: string): string {
+	const resolved = path.resolve(filePath);
+	const allowedDir = path.resolve(process.cwd(), ALLOWED_LOG_DIR);
+	const relative = path.relative(allowedDir, resolved);
+
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		throw new Error(`Invalid log file path: ${filePath} must be within ${ALLOWED_LOG_DIR}`);
+	}
+
+	return resolved;
+}
+
+/**
+ * Get current verbose mode state
+ */
+export function isVerbose(): boolean {
+	return loggerState.verboseMode;
+}
+
+/**
+ * Get current debug mode state
+ */
+export function isDebug(): boolean {
+	return loggerState.debugMode;
+}
 
 /**
  * Set verbose mode
  */
 export function setVerbose(verbose: boolean): void {
-	verboseMode = verbose;
+	loggerState.verboseMode = verbose;
+	verboseMode = loggerState.verboseMode;
+}
+
+/**
+ * Set debug mode (implies verbose)
+ */
+export function setDebug(debug: boolean): void {
+	loggerState.debugMode = debug;
+	if (debug) {
+		loggerState.verboseMode = true;
+	}
+	verboseMode = loggerState.verboseMode;
+}
+
+// BUG FIX: Export a getter function instead of a stale primitive value
+// This ensures consumers always get the current state, not the initial value
+export function getVerboseMode(): boolean {
+	return loggerState.verboseMode;
+}
+
+// Keep backward compatibility export but mark as deprecated
+/** @deprecated Use getVerboseMode() instead for live value */
+export let verboseMode = loggerState.verboseMode;
+
+/**
+ * Log levels for structured logging
+ */
+export type LogLevel = "debug" | "info" | "success" | "warn" | "error";
+
+/**
+ * Structured log entry interface
+ */
+export interface LogEntry {
+	timestamp: string;
+	level: LogLevel;
+	component: string;
+	message: string;
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Log sink interface for extensible logging
+ */
+export interface LogSink {
+	write(entry: LogEntry): void;
+}
+
+/**
+ * Default console log sink with colors
+ */
+class ConsoleLogSink implements LogSink {
+	write(entry: LogEntry): void {
+		// Defensive: validate entry has required fields
+		if (!entry || typeof entry !== "object") {
+			console.error("[Logger] Invalid log entry");
+			return;
+		}
+		const timestamp = entry.timestamp ?? new Date().toISOString();
+		const level = entry.level ?? "info";
+		const component = entry.component ?? "ralphy";
+		const message = entry.message ?? "";
+		const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
+
+		switch (level) {
+			case "error":
+				console.error(pc.red(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				break;
+			case "warn":
+				console.warn(pc.yellow(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				break;
+			case "success":
+				console.log(pc.green(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				break;
+			case "info":
+				console.log(pc.blue(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				break;
+			case "debug":
+				console.log(pc.gray(`${prefix} ${component ? `[${component}] ` : ""}${message}`));
+				break;
+			default:
+				console.log(`${prefix} ${component ? `[${component}] ` : ""}${message}`);
+		}
+	}
+}
+
+// Global log sink instance
+let logSink: LogSink = new ConsoleLogSink();
+
+/**
+ * Set a custom log sink for extensible logging
+ */
+export function setLogSink(sink: LogSink): void {
+	logSink = sink;
+}
+
+/**
+ * Get current log sink
+ */
+export function getLogSink(): LogSink {
+	return logSink;
+}
+
+/**
+ * Internal function to create log entry
+ * Sanitizes secrets from logged data
+ */
+function createLogEntry(level: LogLevel, component: string | undefined, args: unknown[]): LogEntry {
+	const rawMessage = args
+		.map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+		.join(" ");
+	// Sanitize secrets from the message
+	const message = sanitizeSecrets(rawMessage);
+
+	return {
+		timestamp: new Date().toISOString(),
+		level,
+		component: component || "ralphy",
+		message,
+	};
+}
+
+/**
+ * Core logging function
+ */
+function log(level: LogLevel, component: string | undefined, ...args: unknown[]): void {
+	// Debug messages only show in verbose or debug mode
+	if (level === "debug" && !loggerState.verboseMode) {
+		return;
+	}
+
+	const entry = createLogEntry(level, component, args);
+	logSink.write(entry);
 }
 
 /**
  * Log info message
  */
 export function logInfo(...args: unknown[]): void {
-	console.log(pc.blue("[INFO]"), ...args);
+	log("info", undefined, ...args);
+}
+
+/**
+ * Log info message with component context
+ */
+export function logInfoContext(component: string, ...args: unknown[]): void {
+	log("info", component, ...args);
 }
 
 /**
  * Log success message
  */
 export function logSuccess(...args: unknown[]): void {
-	console.log(pc.green("[OK]"), ...args);
+	log("success", undefined, ...args);
+}
+
+/**
+ * Log success message with component context
+ */
+export function logSuccessContext(component: string, ...args: unknown[]): void {
+	log("success", component, ...args);
 }
 
 /**
  * Log warning message
  */
 export function logWarn(...args: unknown[]): void {
-	console.log(pc.yellow("[WARN]"), ...args);
+	log("warn", undefined, ...args);
+}
+
+/**
+ * Log warning message with component context
+ */
+export function logWarnContext(component: string, ...args: unknown[]): void {
+	log("warn", component, ...args);
 }
 
 /**
  * Log error message
  */
 export function logError(...args: unknown[]): void {
-	console.error(pc.red("[ERROR]"), ...args);
+	log("error", undefined, ...args);
+}
+
+/**
+ * Log error message with component context
+ */
+export function logErrorContext(component: string, ...args: unknown[]): void {
+	log("error", component, ...args);
 }
 
 /**
  * Log debug message (only in verbose mode)
  */
 export function logDebug(...args: unknown[]): void {
-	if (verboseMode) {
-		console.log(pc.dim("[DEBUG]"), ...args);
+	log("debug", undefined, ...args);
+}
+
+/**
+ * Log debug message with component context
+ */
+export function logDebugContext(component: string, ...args: unknown[]): void {
+	log("debug", component, ...args);
+}
+
+/**
+ * JSON file log sink for structured logging to file
+ */
+export class JsonFileLogSink implements LogSink {
+	private filePath: string;
+	private buffer: LogEntry[] = [];
+	private flushInterval: number;
+	private maxBufferSize: number;
+	// BUG FIX: Use proper nullable type instead of type cast hack
+	private flushTimer: NodeJS.Timeout | null = null;
+
+	constructor(filePath: string, options?: { flushIntervalMs?: number; maxBufferSize?: number }) {
+		// Validate path to prevent path traversal attacks
+		this.filePath = validateLogPath(filePath);
+		this.flushInterval = options?.flushIntervalMs ?? 1000;
+		this.maxBufferSize = options?.maxBufferSize ?? 100;
+
+		// Auto-flush buffer periodically
+		this.flushTimer = setInterval(() => {
+			try {
+				this.flush();
+			} catch (err) {
+				console.error(`Failed to flush log buffer: ${err}`);
+			}
+		}, this.flushInterval);
 	}
+
+	private isFlushing = false;
+
+	write(entry: LogEntry): void {
+		this.buffer.push(entry);
+
+		if (this.buffer.length >= this.maxBufferSize) {
+			this.flush();
+		}
+	}
+
+	private flush(): void {
+		// Prevent concurrent flushes (race condition fix)
+		if (this.isFlushing || this.buffer.length === 0) return;
+
+		this.isFlushing = true;
+		let currentBuffer: LogEntry[] = [];
+
+		try {
+			// ATOMIC: Swap buffers instead of copy-then-clear
+			// This prevents race conditions where write() is called between copy and clear
+			currentBuffer = this.buffer;
+			this.buffer = []; // New empty buffer assigned atomically
+			const lines = `${currentBuffer.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+			appendFileSync(this.filePath, lines, "utf-8");
+		} catch (error) {
+			console.error(`Failed to write to log file: ${error}`);
+			// Limit buffer size to prevent memory exhaustion on persistent write failures
+			const MAX_BUFFER_SIZE = 10000;
+			const combined = [...currentBuffer, ...this.buffer];
+			// Keep only the most recent entries, discard oldest to prevent memory leak
+			if (combined.length > MAX_BUFFER_SIZE) {
+				this.buffer = combined.slice(-MAX_BUFFER_SIZE);
+				console.warn(`Log buffer truncated to ${MAX_BUFFER_SIZE} entries due to write failure`);
+			} else {
+				this.buffer = combined;
+			}
+		} finally {
+			this.isFlushing = false;
+		}
+	}
+
+	/**
+	 * Dispose of the file log sink, stopping the flush timer.
+	 * Call this when done logging to prevent memory leaks.
+	 */
+	dispose(): void {
+		// BUG FIX: Proper nullable type check without type cast hack
+		if (this.flushTimer !== null) {
+			clearInterval(this.flushTimer);
+			this.flushTimer = null;
+		}
+		// Final flush to ensure all logs are written
+		this.flush();
+	}
+}
+
+/**
+ * Multi-sink that writes to multiple log sinks
+ */
+export class MultiLogSink implements LogSink {
+	private sinks: LogSink[];
+
+	constructor(sinks: LogSink[]) {
+		this.sinks = sinks;
+	}
+
+	write(entry: LogEntry): void {
+		for (const sink of this.sinks) {
+			try {
+				sink.write(entry);
+			} catch (error) {
+				console.error(`Log sink failed: ${error}`);
+			}
+		}
+	}
+
+	addSink(sink: LogSink): void {
+		this.sinks.push(sink);
+	}
+}
+
+/**
+ * Filtered log sink that only passes certain log levels
+ */
+export class FilteredLogSink implements LogSink {
+	private sink: LogSink;
+	private minLevel: LogLevel;
+	private levelPriority: Record<LogLevel, number> = {
+		debug: 0,
+		info: 1,
+		success: 2,
+		warn: 3,
+		error: 4,
+	};
+
+	constructor(sink: LogSink, minLevel: LogLevel) {
+		this.sink = sink;
+		this.minLevel = minLevel;
+	}
+
+	write(entry: LogEntry): void {
+		if (this.levelPriority[entry.level] >= this.levelPriority[this.minLevel]) {
+			this.sink.write(entry);
+		}
+	}
+}
+
+/**
+ * Initialize structured logging with file output
+ * @param logFilePath - Path to JSON log file (optional)
+ * @param minLevel - Minimum log level to record (default: "info")
+ */
+export function initializeStructuredLogging(
+	logFilePath?: string,
+	minLevel: LogLevel = "info",
+): void {
+	const sinks: LogSink[] = [new ConsoleLogSink()];
+
+	if (logFilePath) {
+		const fileSink = new JsonFileLogSink(logFilePath);
+		const filteredFileSink = new FilteredLogSink(fileSink, minLevel);
+		sinks.push(filteredFileSink);
+	}
+
+	setLogSink(new MultiLogSink(sinks));
 }
 
 /**

--- a/cli/src/ui/logger.ts
+++ b/cli/src/ui/logger.ts
@@ -112,7 +112,7 @@ class ConsoleLogSink implements LogSink {
 				console.warn(pc.yellow(`${prefix} ${message}`));
 				break;
 			case "success":
-				console.log(pc.green(`${prefix} ${message}`));
+				console.log(pc.green(`[OK] ${message}`));
 				break;
 			case "info":
 				console.log(pc.blue(`${prefix} ${message}`));

--- a/cli/src/utils/ai-output-parser.ts
+++ b/cli/src/utils/ai-output-parser.ts
@@ -1,0 +1,155 @@
+import { parseJsonLine, TextSchema, ToolUseSchema } from "./json-validation.ts";
+
+export interface ParsedStep {
+	thought?: string;
+	tool?: string;
+	toolArgs?: string;
+	reading?: string;
+	writing?: string;
+	running?: string;
+	executed?: string;
+	raw?: string;
+}
+
+/**
+ * Parse AI output step and extract structured information
+ */
+export function parseAIStep(step: string): ParsedStep {
+	const parsed: ParsedStep = { raw: step };
+
+	// Try to parse as JSON first
+	const result = parseJsonLine(step);
+	if (result) {
+		const { event, remaining } = result;
+
+		// If there's remaining text, treat it as a thought/progress message
+		if (remaining) {
+			parsed.thought = remaining;
+		}
+
+		// Extract text/response content
+		const textResult = TextSchema.safeParse(event);
+		if (textResult.success) {
+			const textEvent = textResult.data;
+			if (textEvent.part?.text) {
+				const text = textEvent.part.text;
+
+				// Try to categorize based on content patterns
+				if (text.startsWith("[thinking") || text.startsWith("Thinking")) {
+					parsed.thought = text;
+				} else if (text.startsWith("Running") || text.startsWith("Executing")) {
+					parsed.running = text;
+				} else if (text.startsWith("Reading") || text.startsWith("Examining")) {
+					parsed.reading = text;
+				} else if (text.startsWith("Writing") || text.startsWith("Creating") || text.startsWith("Updating")) {
+					parsed.writing = text;
+				} else if (text.startsWith("Executed") || text.startsWith("Finished")) {
+					parsed.executed = text;
+				} else {
+					// Default: if it's text content, treat as general progress
+					parsed.thought = text;
+				}
+			}
+		}
+
+		// Extract tool use content
+		const toolUseResult = ToolUseSchema.safeParse(event);
+		if (toolUseResult.success) {
+			const toolUse = toolUseResult.data;
+			const toolName = toolUse.tool || toolUse.part?.tool || "";
+			const toolInput = toolUse.part?.state?.input;
+
+			if (toolName) {
+				parsed.tool = toolName;
+
+				// Extract meaningful summary of arguments
+				let argSummary = "";
+				if (toolInput) {
+					if (typeof toolInput === "string") {
+						argSummary = toolInput;
+					} else if (typeof toolInput === "object" && toolInput !== null && !Array.isArray(toolInput)) {
+						// Heuristics for common tools
+						const input = toolInput as Record<string, unknown>;
+						argSummary =
+							String(input.pattern || "") ||
+							String(input.path || "") ||
+							String(input.filePath || "") ||
+							String(input.command || "") ||
+							JSON.stringify(toolInput);
+					}
+				}
+
+				parsed.toolArgs = argSummary;
+
+				// Map specific tools to display categories with refined messages
+				const lowerTool = toolName.toLowerCase();
+				const shortArgs = argSummary;
+
+				if (lowerTool === "read") {
+					parsed.reading = `Read: ${shortArgs} `;
+				} else if (lowerTool === "glob") {
+					parsed.reading = `Glob: ${shortArgs} `;
+				} else if (lowerTool === "grep") {
+					parsed.reading = `Grep: ${shortArgs} `;
+				} else if (lowerTool === "ls") {
+					parsed.reading = `List: ${shortArgs} `;
+				} else if (lowerTool === "write" || lowerTool === "edit" || lowerTool === "create") {
+					parsed.writing = `Write: ${shortArgs} `;
+				} else if (lowerTool === "run" || lowerTool === "execute" || lowerTool === "terminal") {
+					parsed.running = `Run: ${shortArgs} `;
+				} else {
+					// Catch-all for other tools
+					parsed.tool = `${toolName}: ${shortArgs} `;
+				}
+			}
+		}
+	}
+
+	return parsed;
+}
+
+/**
+ * Format parsed step for display
+ */
+export function formatParsedStep(step: ParsedStep, agentNum?: number): string | null {
+	const prefix = agentNum !== undefined ? `Agent ${agentNum}: ` : "";
+
+	// Prioritize concrete actions over generic thoughts
+	if (step.writing) {
+		return `${prefix}${step.writing} `;
+	}
+
+	if (step.reading) {
+		return `${prefix}${step.reading} `;
+	}
+
+	if (step.running) {
+		return `${prefix}${step.running} `;
+	}
+
+	if (step.thought) {
+		// Clean up common "Thinking:" prefixes since we wrap in {} later
+		const cleanedThought = step.thought.replace(/^(Thinking|Analyzing|Considering|Warning|Waiting)[:\s]*/i, "").trim();
+		return `${prefix}${cleanedThought} `;
+	}
+
+	if (step.executed) {
+		return `${prefix} Done: ${step.executed.substring(0, 100)} `;
+	}
+
+	if (step.tool) {
+		return `${prefix} Tool: ${step.tool} `;
+	}
+
+	// If raw but couldn't parse, truncate and show
+	if (step.raw && step.raw.length > 0) {
+		const trimmed = step.raw.trim();
+		if (trimmed.startsWith("{") || trimmed.startsWith('"')) {
+			// It's JSON we couldn't parse, skip it
+			return null;
+		}
+		return `${prefix}${trimmed.substring(0, 100)} `;
+	}
+
+	return null;
+}

--- a/cli/src/utils/cleanup.ts
+++ b/cli/src/utils/cleanup.ts
@@ -106,7 +106,12 @@ export async function runCleanup(): Promise<void> {
 		}
 	}
 
-	await Promise.allSettled(promises);
+	const results = await Promise.allSettled(promises);
+	for (const result of results) {
+		if (result.status === "rejected") {
+			logWarn(`Cleanup task failed: ${result.reason}`);
+		}
+	}
 	cleanupRegistry.clear();
 	isCleaningUp = false;
 }

--- a/cli/src/utils/cleanup.ts
+++ b/cli/src/utils/cleanup.ts
@@ -1,0 +1,146 @@
+import type { ChildProcess } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { logDebug, logWarn } from "../ui/logger.ts";
+
+type CleanupFn = () => Promise<void> | void;
+
+const cleanupRegistry: Set<CleanupFn> = new Set();
+const trackedProcesses: Set<ChildProcess> = new Set();
+let isCleaningUp = false;
+
+function isProcessRunning(proc: ChildProcess): boolean {
+	return proc.exitCode === null && proc.signalCode === null;
+}
+
+/**
+ * Register a function to be called on process exit or manual cleanup
+ */
+export function registerCleanup(fn: CleanupFn): () => void {
+	cleanupRegistry.add(fn);
+	return () => cleanupRegistry.delete(fn);
+}
+
+/**
+ * Register a child process to be tracked and killed on exit
+ */
+export function registerProcess(proc: ChildProcess): () => void {
+	trackedProcesses.add(proc);
+
+	const remove = () => trackedProcesses.delete(proc);
+
+	proc.on("exit", remove);
+	proc.on("error", remove);
+
+	return remove;
+}
+
+/**
+ * Run all registered cleanup functions and kill tracked processes
+ */
+export async function runCleanup(): Promise<void> {
+	if (isCleaningUp) return;
+	isCleaningUp = true;
+
+	// 1. Kill all tracked child processes with verification
+	for (const proc of trackedProcesses) {
+		try {
+			if (proc.pid && isProcessRunning(proc)) {
+				const pid = proc.pid;
+
+				if (process.platform === "win32") {
+					// Windows needs taskkill for robust child tree termination
+					const result = spawnSync("taskkill", ["/pid", String(pid), "/f", "/t"], {
+						stdio: "pipe",
+					});
+
+					// Verify the process was actually killed
+					// Status 128 = process already exited, which is fine
+					if (result.status !== 0 && result.status !== 128) {
+						logWarn(`taskkill may have failed for PID ${pid} (exit code: ${result.status})`);
+						if (result.stderr) {
+							logDebug(`taskkill stderr: ${result.stderr.toString()}`);
+						}
+					}
+
+					await new Promise((resolve) => setTimeout(resolve, 500));
+					if (isProcessRunning(proc)) {
+						logWarn(`Process ${pid} may still be running after taskkill`);
+					}
+				} else {
+					// Try graceful termination first
+					proc.kill("SIGTERM");
+
+					// Wait a bit and verify it's dead
+					await new Promise((resolve) => setTimeout(resolve, 1000));
+
+					// Check if process is still running
+					if (isProcessRunning(proc)) {
+						proc.kill("SIGKILL");
+
+						// Final verification
+						await new Promise((resolve) => setTimeout(resolve, 500));
+						if (isProcessRunning(proc)) {
+							logWarn(`Failed to terminate process ${pid} after SIGKILL`);
+						}
+					}
+				}
+			}
+		} catch (err) {
+			// Process termination failed, continue cleanup
+			logDebug(`Failed to terminate process ${proc.pid}: ${err}`);
+		}
+	}
+	trackedProcesses.clear();
+
+	// 2. Run registered cleanup functions
+	const promises: Promise<void>[] = [];
+	for (const fn of cleanupRegistry) {
+		try {
+			const result = fn();
+			if (result instanceof Promise) {
+				promises.push(result);
+			}
+		} catch (err) {
+			// Log sync errors but continue with other cleanup functions
+			promises.push(Promise.reject(err));
+		}
+	}
+
+	await Promise.allSettled(promises);
+	cleanupRegistry.clear();
+	isCleaningUp = false;
+}
+
+let isShuttingDown = false;
+
+/**
+ * Setup process signal handlers for cleanup
+ */
+export function setupSignalHandlers(): void {
+	const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+
+	for (const signal of signals) {
+		process.on(signal, async () => {
+			// Prevent duplicate cleanup runs
+			if (isShuttingDown) {
+				process.stdout.write(`\nReceived ${signal}, cleanup already in progress...\n`);
+				return;
+			}
+			isShuttingDown = true;
+
+			// Use writeSync to avoid event loop issues during exit
+			process.stdout.write(`\nReceived ${signal}, cleaning up processes and files...\n`);
+
+			try {
+				await runCleanup();
+				process.exit(0);
+			} catch (error) {
+				process.stderr.write(`\nCleanup failed: ${error}\n`);
+				process.exit(1);
+			}
+		});
+	}
+
+	// Note: uncaughtException is handled in cli/src/index.ts for the main process
+	// This avoids duplicate handlers and ensures consistent error handling
+}

--- a/cli/src/utils/cleanup.ts
+++ b/cli/src/utils/cleanup.ts
@@ -112,11 +112,17 @@ export async function runCleanup(): Promise<void> {
 }
 
 let isShuttingDown = false;
+let handlersRegistered = false;
 
 /**
  * Setup process signal handlers for cleanup
  */
 export function setupSignalHandlers(): void {
+	if (handlersRegistered) {
+		return;
+	}
+	handlersRegistered = true;
+
 	const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
 
 	for (const signal of signals) {

--- a/cli/src/utils/errors.ts
+++ b/cli/src/utils/errors.ts
@@ -1,0 +1,131 @@
+/**
+ * Standardized error handling utilities for consistent error types across the codebase
+ */
+
+export class RalphyError extends Error {
+	public readonly code: string;
+	public readonly context?: Record<string, unknown>;
+
+	constructor(message: string, code = "RALPHY_ERROR", context?: Record<string, unknown>) {
+		super(message);
+		this.name = "RalphyError";
+		this.code = code;
+		this.context = context;
+
+		// Maintains proper stack trace for where our error was thrown (only available on V8)
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, RalphyError);
+		}
+	}
+}
+
+export class ValidationError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "VALIDATION_ERROR", context);
+		this.name = "ValidationError";
+	}
+}
+
+export class TimeoutError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "TIMEOUT_ERROR", context);
+		this.name = "TimeoutError";
+	}
+}
+
+export class LockError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "LOCK_ERROR", context);
+		this.name = "LockError";
+	}
+}
+
+export class ProcessError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "PROCESS_ERROR", context);
+		this.name = "ProcessError";
+	}
+}
+
+export class SandboxError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "SANDBOX_ERROR", context);
+		this.name = "SandboxError";
+	}
+}
+
+/**
+ * Convert any error to a standardized format
+ */
+export function standardizeError(error: unknown): RalphyError {
+	if (error instanceof RalphyError) {
+		return error;
+	}
+
+	if (error instanceof Error) {
+		return new RalphyError(error.message, "UNKNOWN_ERROR", {
+			originalName: error.name,
+			originalStack: error.stack,
+		});
+	}
+
+	if (typeof error === "string") {
+		return new RalphyError(error, "STRING_ERROR");
+	}
+
+	return new RalphyError(String(error), "UNKNOWN_ERROR", { originalType: typeof error });
+}
+
+/**
+ * Check if an error is retryable
+ */
+export function isRetryableError(error: unknown): boolean {
+	const standardized = standardizeError(error);
+
+	const retryableCodes = ["TIMEOUT_ERROR", "LOCK_ERROR", "PROCESS_ERROR", "NETWORK_ERROR", "RATE_LIMIT_ERROR"];
+
+	const retryableMessages = [
+		"timeout",
+		"connection refused",
+		"network",
+		"rate limit",
+		"too many requests",
+		"temporary failure",
+		"try again",
+		"locked",
+		"conflict",
+		"connection error",
+		"unable to connect",
+		"internet connection",
+		"econnrefused",
+		"econnreset",
+		"socket hang up",
+		"fetch failed",
+	];
+
+	const message = standardized.message.toLowerCase();
+
+	// Check error code
+	if (retryableCodes.includes(standardized.code)) {
+		return true;
+	}
+
+	// Check error message
+	return retryableMessages.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * Create error with context for logging
+ */
+export function createErrorWithContext(error: unknown, context: Record<string, unknown>): RalphyError {
+	const standardized = standardizeError(error);
+
+	if (standardized.context) {
+		return new RalphyError(standardized.message, standardized.code, {
+			...standardized.context,
+			...context,
+		});
+	}
+
+	return new RalphyError(standardized.message, standardized.code, context);
+}

--- a/cli/src/utils/file-indexer.ts
+++ b/cli/src/utils/file-indexer.ts
@@ -1,0 +1,1025 @@
+/**
+ * File Indexer Module
+ *
+ * Provides semantic chunking for large codebases and file hash caching for unchanged files.
+ * This module indexes the codebase with file metadata (path, hash, size, mtime, keywords)
+ * and provides semantic search to find relevant files based on task keywords.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { DEFAULT_IGNORE_PATTERNS, MAX_FILE_SIZE_FOR_HASH } from "../config/constants.ts";
+import { RALPHY_DIR } from "../config/loader.ts";
+import { logDebug } from "../ui/logger.ts";
+
+// Constants
+const FILE_INDEX_CACHE = "file-index.json";
+const MAX_KEYWORDS_PER_FILE = 20;
+const MAX_CONTENT_PREVIEW_LENGTH = 500;
+const RELEVANCE_THRESHOLD = 0.1;
+
+/**
+ * Maximum glob pattern length to prevent ReDoS attacks
+ */
+const MAX_GLOB_PATTERN_LENGTH = 1000;
+
+/**
+ * File metadata entry in the index
+ */
+export interface FileIndexEntry {
+	/** Relative path from workspace root */
+	path: string;
+	/** File content hash (sha256, first 16 chars) */
+	hash: string;
+	/** File size in bytes */
+	size: number;
+	/** Last modification time (ms since epoch) */
+	mtime: number;
+	/** Extracted keywords from path and content */
+	keywords: string[];
+	/** Content preview for semantic analysis */
+	preview?: string;
+	/** File extension */
+	extension: string;
+	/** Directory depth */
+	depth: number;
+}
+
+/**
+ * The complete file index for a workspace
+ */
+export interface FileIndex {
+	/** Version for cache invalidation */
+	version: number;
+	/** Timestamp of index creation */
+	timestamp: number;
+	/** Workspace root path */
+	workDir: string;
+	/** Map of relative paths to file entries */
+	files: Map<string, FileIndexEntry>;
+	/** Total files indexed */
+	totalFiles: number;
+	/** Total size of all indexed files */
+	totalSize: number;
+}
+
+/**
+ * Serialized version of FileIndex for JSON storage
+ */
+interface SerializedFileIndex {
+	version: number;
+	timestamp: number;
+	workDir: string;
+	files: Record<string, FileIndexEntry>;
+	totalFiles: number;
+	totalSize: number;
+}
+
+// In-memory cache of file indexes
+const indexCache = new Map<string, FileIndex>();
+
+// Track promises for workspaces being indexed to allow waiting
+const indexingPromises = new Map<string, Promise<FileIndex>>();
+
+/**
+ * Deep clone a FileIndex to return an immutable copy
+ * Prevents callers from modifying the shared cache
+ */
+function cloneFileIndex(index: FileIndex): FileIndex {
+	return {
+		version: index.version,
+		timestamp: index.timestamp,
+		workDir: index.workDir,
+		files: new Map(index.files),
+		totalFiles: index.totalFiles,
+		totalSize: index.totalSize,
+	};
+}
+
+/**
+ * Get the path to the file index cache
+ */
+function getIndexCachePath(workDir: string): string {
+	return join(workDir, RALPHY_DIR, FILE_INDEX_CACHE);
+}
+
+/**
+ * Check if a file should be ignored based on patterns
+ */
+function shouldIgnoreFile(filePath: string, ignorePatterns: string[]): boolean {
+	const normalizedPath = filePath.replace(/\\/g, "/");
+
+	for (const pattern of ignorePatterns) {
+		if (matchesGlob(normalizedPath, pattern)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Convert glob pattern to regex
+ */
+function matchesGlob(filePath: string, pattern: string): boolean {
+	// Handle ** patterns properly
+	const regexPattern = globToRegex(pattern);
+	return regexPattern.test(filePath);
+}
+
+/**
+ * Convert glob pattern to regex
+ *
+ * SECURITY NOTE: This function includes protections against ReDoS attacks:
+ * - Input length is limited to MAX_GLOB_PATTERN_LENGTH
+ * - Uses non-backtracking patterns where possible
+ */
+function globToRegex(pattern: string): RegExp {
+	const safePattern =
+		pattern.length > MAX_GLOB_PATTERN_LENGTH
+			? pattern.slice(0, MAX_GLOB_PATTERN_LENGTH)
+			: pattern;
+
+	// Limit pattern length to prevent ReDoS attacks
+	if (safePattern.length < pattern.length) {
+		logDebug(`Glob pattern too long (${pattern.length} > ${MAX_GLOB_PATTERN_LENGTH}), truncating`);
+	}
+
+	// Escape special regex characters except * and ?
+	// Use a bounded approach to prevent catastrophic backtracking
+	let regex = safePattern
+		.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+		.replace(/\*\*/g, "\0DOUBLESTAR\0") // Temporarily mark **
+		.replace(/\*/g, "[^/]*") // Single * matches anything except /
+		.replace(/\?/g, "[^/]"); // ? matches single char except /
+
+	// Handle ** (match any number of directories) using non-capturing group
+	// The (?:.*/)? pattern is bounded - it won't cause catastrophic backtracking
+	regex = regex.replace(/\0DOUBLESTAR\0/g, "(?:.*/)?");
+
+	// Handle directory separators
+	regex = regex.replace(/\//g, "[/\\\\]");
+
+	// Anchor to start
+	regex = `^${regex}`;
+
+	// Match at end if pattern doesn't end with /**
+	if (!safePattern.endsWith("/**")) {
+		regex += "$";
+	}
+
+	return new RegExp(regex, "i");
+}
+
+/**
+ * Extract keywords from a file path
+ */
+function extractPathKeywords(filePath: string): string[] {
+	const keywords = new Set<string>();
+
+	// Split path into components
+	const parts = filePath.split(/[/\\]/);
+
+	for (const part of parts) {
+		// Skip empty parts and common non-descriptive names
+		if (!part || part === "." || part === "..") continue;
+
+		// Extract words from camelCase, PascalCase, snake_case, kebab-case
+		const words = part
+			.replace(/\.[^.]+$/, "") // Remove extension
+			.split(/[_-]/) // Split by underscore and hyphen
+			.flatMap((word) => {
+				// Split camelCase/PascalCase
+				return word
+					.replace(/([a-z])([A-Z])/g, "$1 $2")
+					.split(/\s+/)
+					.filter((w) => w.length > 2);
+			});
+
+		for (const word of words) {
+			const lower = word.toLowerCase();
+			if (isSignificantKeyword(lower)) {
+				keywords.add(lower);
+			}
+		}
+
+		// Add the full filename (without extension) as a keyword
+		const nameWithoutExt = part.replace(/\.[^.]+$/, "").toLowerCase();
+		if (nameWithoutExt.length > 2 && !isCommonWord(nameWithoutExt)) {
+			keywords.add(nameWithoutExt);
+		}
+	}
+
+	// Add extension as keyword
+	const ext = filePath.split(".").pop()?.toLowerCase();
+	if (ext && ext !== filePath) {
+		keywords.add(ext);
+	}
+
+	return Array.from(keywords);
+}
+
+/**
+ * Extract keywords from file content
+ */
+function extractContentKeywords(content: string, maxKeywords = 10): string[] {
+	const keywords = new Set<string>();
+
+	// Extract function/class/variable names from code
+	const patterns = [
+		// Function declarations
+		/(?:function|def|fn|func)\s+(\w+)/g,
+		// Class declarations
+		/(?:class|interface|type|struct)\s+(\w+)/g,
+		// Variable declarations (const, let, var)
+		/(?:const|let|var)\s+(\w+)\s*[=:]/g,
+		// Export declarations
+		/export\s+(?:default\s+)?(?:class|function|const|let|var)?\s*(\w+)/g,
+		// Import statements - extract imported names
+		/import\s+{([^}]+)}/g,
+		// Python imports
+		/from\s+\S+\s+import\s+([^\n]+)/g,
+		// Go/Rust function signatures
+		/fn\s+(\w+)\s*\(/g,
+		// React components (PascalCase functions)
+		/const\s+([A-Z][a-zA-Z0-9]*)\s*[:=]/g,
+	];
+
+	for (const pattern of patterns) {
+		let match: RegExpExecArray | null = null;
+		// biome-ignore lint/suspicious/noAssignInExpressions: Standard regex loop pattern
+		while ((match = pattern.exec(content)) !== null) {
+			const names = match[1]
+				.split(/[,\s]+/)
+				.map((n) => n.trim())
+				.filter((n) => n.length > 2 && isSignificantKeyword(n.toLowerCase()));
+
+			for (const name of names) {
+				keywords.add(name.toLowerCase());
+			}
+		}
+	}
+
+	// Extract common words that appear frequently
+	const words = content.toLowerCase().match(/\b[a-z]{3,}\b/g) || [];
+
+	const wordFreq = new Map<string, number>();
+	for (const word of words) {
+		if (!isCommonWord(word) && isSignificantKeyword(word)) {
+			wordFreq.set(word, (wordFreq.get(word) || 0) + 1);
+		}
+	}
+
+	// Add most frequent words
+	const sortedWords = Array.from(wordFreq.entries())
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, maxKeywords);
+
+	for (const [word] of sortedWords) {
+		keywords.add(word);
+	}
+
+	return Array.from(keywords).slice(0, maxKeywords);
+}
+
+/**
+ * Check if a word is a common/insignificant word
+ */
+function isCommonWord(word: string): boolean {
+	const commonWords = new Set([
+		"the",
+		"and",
+		"for",
+		"are",
+		"but",
+		"not",
+		"you",
+		"all",
+		"can",
+		"had",
+		"her",
+		"was",
+		"one",
+		"our",
+		"out",
+		"day",
+		"get",
+		"has",
+		"him",
+		"his",
+		"how",
+		"its",
+		"may",
+		"new",
+		"now",
+		"old",
+		"see",
+		"two",
+		"who",
+		"boy",
+		"did",
+		"she",
+		"use",
+		"way",
+		"many",
+		"oil",
+		"sit",
+		"set",
+		"run",
+		"eat",
+		"far",
+		"sea",
+		"eye",
+		"ago",
+		"off",
+		"too",
+		"any",
+		"say",
+		"man",
+		"try",
+		"ask",
+		"end",
+		"why",
+		"let",
+		"put",
+		"own",
+		"tell",
+		"very",
+		"when",
+		"come",
+		"here",
+		"just",
+		"like",
+		"long",
+		"make",
+		"over",
+		"such",
+		"take",
+		"than",
+		"them",
+		"well",
+		"were",
+		"will",
+		"with",
+		"have",
+		"from",
+		"they",
+		"know",
+		"want",
+		"been",
+		"good",
+		"much",
+		"some",
+		"time",
+		"this",
+		"that",
+		"would",
+		"there",
+		"their",
+		"what",
+		"said",
+		"each",
+		"which",
+		"about",
+		"could",
+		"other",
+		"after",
+		"first",
+		"never",
+		"these",
+		"think",
+		"where",
+		"being",
+		"every",
+		"great",
+		"might",
+		"shall",
+		"still",
+		"those",
+		"while",
+		"true",
+		"false",
+		"null",
+		"undefined",
+		"return",
+		"import",
+		"export",
+		"default",
+		"async",
+		"await",
+		"yield",
+		"throw",
+		"catch",
+		"finally",
+		"break",
+		"continue",
+		"switch",
+		"case",
+		"try",
+		"new",
+	]);
+	return commonWords.has(word.toLowerCase());
+}
+
+/**
+ * Check if a keyword is significant (not too short, not numeric)
+ */
+function isSignificantKeyword(word: string): boolean {
+	if (word.length < 3) return false;
+	if (/^\d+$/.test(word)) return false;
+	if (/^[0-9a-f]{8,}$/i.test(word)) return false; // Likely a hash
+	return true;
+}
+
+/**
+ * Extract keywords from a task description
+ */
+export function extractTaskKeywords(taskDescription: string): string[] {
+	const keywords = new Set<string>();
+
+	// Extract file paths mentioned in the task
+	const pathMatches = taskDescription.match(/[\w\-./\\]+\.[\w]+/g) || [];
+	for (const path of pathMatches) {
+		const pathKeywords = extractPathKeywords(path);
+		for (const kw of pathKeywords) {
+			keywords.add(kw);
+		}
+	}
+
+	// Extract camelCase/PascalCase words (likely identifiers)
+	const identifierMatches = taskDescription.match(/\b[a-z]+[A-Z][a-zA-Z0-9]*\b/g) || [];
+	for (const id of identifierMatches) {
+		const words = id
+			.replace(/([a-z])([A-Z])/g, "$1 $2")
+			.split(/\s+/)
+			.filter((w) => w.length > 2);
+		for (const word of words) {
+			keywords.add(word.toLowerCase());
+		}
+	}
+
+	// Extract technical terms and concepts
+	const techTerms = taskDescription.match(/\b[A-Z][a-z]+[A-Z][a-zA-Z]+\b/g) || [];
+	for (const term of techTerms) {
+		keywords.add(term.toLowerCase());
+	}
+
+	// Extract words that look like file names or components
+	const componentMatches =
+		taskDescription.match(
+			/\b[A-Z][a-zA-Z0-9]*(?:Component|Module|Service|Handler|Controller|Model|View|Util|Helper|Manager|Store|Context|Provider|Hook)\b/g,
+		) || [];
+	for (const comp of componentMatches) {
+		keywords.add(comp.toLowerCase());
+	}
+
+	// Extract all significant words
+	const allWords = taskDescription.toLowerCase().match(/\b[a-z]{3,}\b/g) || [];
+
+	for (const word of allWords) {
+		if (!isCommonWord(word) && isSignificantKeyword(word)) {
+			keywords.add(word);
+		}
+	}
+
+	return Array.from(keywords);
+}
+
+/**
+ * Calculate relevance score between task keywords and file entry
+ */
+function calculateRelevanceScore(taskKeywords: string[], fileEntry: FileIndexEntry): number {
+	let score = 0;
+	const fileKeywords = new Set(fileEntry.keywords);
+
+	for (const taskKw of taskKeywords) {
+		// Exact match in file keywords
+		if (fileKeywords.has(taskKw)) {
+			score += 1.0;
+			continue;
+		}
+
+		// Partial match (task keyword is substring of file keyword or vice versa)
+		for (const fileKw of fileKeywords) {
+			if (fileKw.includes(taskKw) || taskKw.includes(fileKw)) {
+				score += 0.5;
+				break;
+			}
+		}
+
+		// Check if keyword appears in path
+		if (fileEntry.path.toLowerCase().includes(taskKw)) {
+			score += 0.3;
+		}
+	}
+
+	// Normalize by number of task keywords
+	return taskKeywords.length > 0 ? score / taskKeywords.length : 0;
+}
+
+/**
+ * Create a file index entry for a single file
+ */
+function createFileIndexEntry(
+	filePath: string,
+	relPath: string,
+	maxSizeForContent = MAX_FILE_SIZE_FOR_HASH,
+): FileIndexEntry | null {
+	try {
+		const stat = statSync(filePath);
+
+		if (!stat.isFile()) return null;
+
+		// Calculate hash
+		let hash = "";
+		let preview = "";
+		let contentKeywords: string[] = [];
+
+		if (stat.size <= maxSizeForContent) {
+			try {
+				const content = readFileSync(filePath, "utf-8");
+				hash = createHash("sha256").update(content).digest("hex").slice(0, 16);
+				preview = content.slice(0, MAX_CONTENT_PREVIEW_LENGTH);
+				contentKeywords = extractContentKeywords(content, 10);
+			} catch {
+				// Binary or unreadable file - use mtime+size as pseudo-hash
+				hash = createHash("sha256").update(`${stat.mtimeMs}-${stat.size}`).digest("hex").slice(0, 16);
+			}
+		} else {
+			// Large file - use mtime+size as pseudo-hash
+			hash = createHash("sha256").update(`${stat.mtimeMs}-${stat.size}`).digest("hex").slice(0, 16);
+		}
+
+		// Extract path keywords
+		const pathKeywords = extractPathKeywords(relPath);
+
+		// Combine keywords
+		const allKeywords = [...new Set([...pathKeywords, ...contentKeywords])].slice(0, MAX_KEYWORDS_PER_FILE);
+
+		// Get extension
+		const ext = relPath.split(".").pop()?.toLowerCase() || "";
+
+		// Calculate depth
+		const depth = relPath.split(/[/\\]/).length - 1;
+
+		return {
+			path: relPath,
+			hash,
+			size: stat.size,
+			mtime: stat.mtimeMs,
+			keywords: allKeywords,
+			preview,
+			extension: ext,
+			depth,
+		};
+	} catch (error) {
+		logDebug(`Failed to index file ${filePath}: ${error}`);
+		return null;
+	}
+}
+
+/**
+ * Index all files in a directory recursively
+ *
+ * Thread-safe: Returns a cloned copy to prevent cache corruption.
+ * Concurrent calls for the same workspace will wait for a single indexing operation.
+ */
+export async function indexWorkspace(
+	workDir: string,
+	options: {
+		ignorePatterns?: string[];
+		forceRebuild?: boolean;
+		maxDepth?: number;
+	} = {},
+): Promise<FileIndex> {
+	const { ignorePatterns = DEFAULT_IGNORE_PATTERNS, forceRebuild = false, maxDepth = 50 } = options;
+
+	// Check memory cache first - return a clone to prevent mutation
+	const cached = indexCache.get(workDir);
+	if (!forceRebuild && cached) {
+		return cloneFileIndex(cached);
+	}
+
+	// Check if another operation is already indexing this workspace
+	const existingPromise = indexingPromises.get(workDir);
+	if (existingPromise) {
+		logDebug(`Waiting for concurrent indexing of ${workDir}...`);
+		const result = await existingPromise;
+		// Return a clone even from the concurrent operation's result
+		return cloneFileIndex(result);
+	}
+
+	// Create the indexing promise to lock this workspace
+	const indexingPromise = performIndexing(workDir, ignorePatterns, forceRebuild, maxDepth);
+	indexingPromises.set(workDir, indexingPromise);
+
+	try {
+		const result = await indexingPromise;
+		// Return a cloned copy to prevent cache corruption
+		return cloneFileIndex(result);
+	} finally {
+		// Always clean up the promise lock
+		indexingPromises.delete(workDir);
+	}
+}
+
+/**
+ * Perform the actual indexing operation
+ */
+async function performIndexing(
+	workDir: string,
+	ignorePatterns: string[],
+	forceRebuild: boolean,
+	maxDepth: number,
+): Promise<FileIndex> {
+	// Double-check cache after acquiring lock (another thread may have completed)
+	const cached = indexCache.get(workDir);
+	if (!forceRebuild && cached) {
+		return cached;
+	}
+
+	// Try to load from disk cache
+	if (!forceRebuild) {
+		const diskCache = loadIndexFromDisk(workDir);
+		if (diskCache) {
+			// Perform incremental update
+			const updated = await incrementalUpdateIndex(workDir, diskCache, ignorePatterns, maxDepth);
+			indexCache.set(workDir, updated);
+			saveIndexToDisk(workDir, updated);
+			return updated;
+		}
+	}
+
+	// Build fresh index
+	const index: FileIndex = {
+		version: 1,
+		timestamp: Date.now(),
+		workDir,
+		files: new Map(),
+		totalFiles: 0,
+		totalSize: 0,
+	};
+
+	// Ensure .ralphy directory exists
+	const ralphyDir = join(workDir, RALPHY_DIR);
+	if (!existsSync(ralphyDir)) {
+		mkdirSync(ralphyDir, { recursive: true });
+	}
+
+	// Collect all files
+	const filesToIndex: string[] = [];
+
+	function collectFiles(dir: string, currentDepth: number) {
+		if (currentDepth > maxDepth) return;
+
+		try {
+			const entries = readdirSync(dir, { withFileTypes: true });
+			for (const entry of entries) {
+				const fullPath = join(dir, entry.name);
+				const relPath = relative(workDir, fullPath);
+
+				if (shouldIgnoreFile(relPath, ignorePatterns)) {
+					continue;
+				}
+
+				if (entry.isDirectory()) {
+					collectFiles(fullPath, currentDepth + 1);
+				} else if (entry.isFile()) {
+					filesToIndex.push(fullPath);
+				}
+			}
+		} catch (error) {
+			logDebug(`Failed to read directory ${dir}: ${error}`);
+		}
+	}
+
+	collectFiles(workDir, 0);
+
+	// Index all collected files
+	for (const filePath of filesToIndex) {
+		const relPath = relative(workDir, filePath);
+		const entry = createFileIndexEntry(filePath, relPath);
+		if (entry) {
+			index.files.set(relPath, entry);
+			index.totalFiles++;
+			index.totalSize += entry.size;
+		}
+	}
+
+	// Cache and save
+	indexCache.set(workDir, index);
+	saveIndexToDisk(workDir, index);
+
+	logDebug(`Indexed ${index.totalFiles} files (${(index.totalSize / 1024 / 1024).toFixed(2)} MB)`);
+
+	return index;
+}
+
+/**
+ * Perform incremental update of file index
+ */
+async function incrementalUpdateIndex(
+	workDir: string,
+	existingIndex: FileIndex,
+	ignorePatterns: string[],
+	maxDepth: number,
+): Promise<FileIndex> {
+	const updatedIndex: FileIndex = {
+		version: existingIndex.version,
+		timestamp: Date.now(),
+		workDir,
+		files: new Map(existingIndex.files),
+		totalFiles: 0,
+		totalSize: 0,
+	};
+
+	const currentFiles = new Set<string>();
+	let reindexedCount = 0;
+	let unchangedCount = 0;
+	let removedCount = 0;
+
+	function scanDirectory(dir: string, currentDepth: number) {
+		if (currentDepth > maxDepth) return;
+
+		try {
+			const entries = readdirSync(dir, { withFileTypes: true });
+			for (const entry of entries) {
+				const fullPath = join(dir, entry.name);
+				const relPath = relative(workDir, fullPath);
+
+				if (shouldIgnoreFile(relPath, ignorePatterns)) {
+					continue;
+				}
+
+				if (entry.isDirectory()) {
+					scanDirectory(fullPath, currentDepth + 1);
+				} else if (entry.isFile()) {
+					currentFiles.add(relPath);
+
+					const existingEntry = updatedIndex.files.get(relPath);
+					const stat = statSync(fullPath);
+
+					if (existingEntry && existingEntry.mtime === stat.mtimeMs && existingEntry.size === stat.size) {
+						// File unchanged - keep existing entry
+						unchangedCount++;
+					} else {
+						// File changed or new - reindex
+						const newEntry = createFileIndexEntry(fullPath, relPath);
+						if (newEntry) {
+							updatedIndex.files.set(relPath, newEntry);
+							reindexedCount++;
+						}
+					}
+				}
+			}
+		} catch (error) {
+			logDebug(`Failed to scan directory ${dir}: ${error}`);
+		}
+	}
+
+	scanDirectory(workDir, 0);
+
+	// Remove deleted files from index
+	for (const [relPath] of updatedIndex.files) {
+		if (!currentFiles.has(relPath)) {
+			updatedIndex.files.delete(relPath);
+			removedCount++;
+		}
+	}
+
+	// Recalculate totals
+	for (const entry of updatedIndex.files.values()) {
+		updatedIndex.totalFiles++;
+		updatedIndex.totalSize += entry.size;
+	}
+
+	logDebug(
+		`Incremental index update: ${unchangedCount} unchanged, ${reindexedCount} reindexed, ${removedCount} removed`,
+	);
+
+	return updatedIndex;
+}
+
+/**
+ * Load index from disk cache
+ */
+function loadIndexFromDisk(workDir: string): FileIndex | null {
+	const cachePath = getIndexCachePath(workDir);
+
+	if (!existsSync(cachePath)) {
+		return null;
+	}
+
+	try {
+		const content = readFileSync(cachePath, "utf-8");
+		const serialized: SerializedFileIndex = JSON.parse(content);
+
+		return {
+			version: serialized.version,
+			timestamp: serialized.timestamp,
+			workDir: serialized.workDir,
+			files: new Map(Object.entries(serialized.files)),
+			totalFiles: serialized.totalFiles,
+			totalSize: serialized.totalSize,
+		};
+	} catch (error) {
+		logDebug(`Failed to load file index from disk: ${error}`);
+		return null;
+	}
+}
+
+/**
+ * Save index to disk cache
+ */
+function saveIndexToDisk(workDir: string, index: FileIndex): void {
+	const cachePath = getIndexCachePath(workDir);
+
+	try {
+		const serialized: SerializedFileIndex = {
+			version: index.version,
+			timestamp: index.timestamp,
+			workDir: index.workDir,
+			files: Object.fromEntries(index.files),
+			totalFiles: index.totalFiles,
+			totalSize: index.totalSize,
+		};
+
+		writeFileSync(cachePath, JSON.stringify(serialized, null, 2));
+	} catch (error) {
+		logDebug(`Failed to save file index to disk: ${error}`);
+	}
+}
+
+/**
+ * Get relevant files for a task based on semantic matching
+ */
+export async function getRelevantFilesForTask(
+	workDir: string,
+	taskDescription: string,
+	options: {
+		maxFiles?: number;
+		minRelevance?: number;
+		includeExtensions?: string[];
+		excludeExtensions?: string[];
+	} = {},
+): Promise<string[]> {
+	const {
+		maxFiles = 50,
+		minRelevance = RELEVANCE_THRESHOLD,
+		includeExtensions,
+		excludeExtensions = ["log", "lock", "map", "min.js", "min.css"],
+	} = options;
+
+	// Get or build file index
+	const index = await indexWorkspace(workDir);
+
+	// Extract keywords from task
+	const taskKeywords = extractTaskKeywords(taskDescription);
+	logDebug(`Task keywords: ${taskKeywords.join(", ")}`);
+
+	if (taskKeywords.length === 0) {
+		// No keywords extracted - return most recently modified files as fallback
+		return Array.from(index.files.values())
+			.sort((a, b) => b.mtime - a.mtime)
+			.slice(0, maxFiles)
+			.map((e) => e.path);
+	}
+
+	// Score all files
+	const scoredFiles: Array<{ path: string; score: number; entry: FileIndexEntry }> = [];
+
+	for (const [path, entry] of index.files) {
+		// Filter by extension
+		if (includeExtensions && !includeExtensions.includes(entry.extension)) {
+			continue;
+		}
+		if (excludeExtensions.includes(entry.extension)) {
+			continue;
+		}
+
+		const score = calculateRelevanceScore(taskKeywords, entry);
+		if (score >= minRelevance) {
+			scoredFiles.push({ path, score, entry });
+		}
+	}
+
+	// Sort by score (descending), then by mtime (most recent first for ties)
+	scoredFiles.sort((a, b) => {
+		if (b.score !== a.score) {
+			return b.score - a.score;
+		}
+		return b.entry.mtime - a.entry.mtime;
+	});
+
+	// Take top N files
+	const relevantFiles = scoredFiles.slice(0, maxFiles).map((s) => s.path);
+
+	logDebug(`Found ${relevantFiles.length} relevant files for task (scored ${scoredFiles.length} total)`);
+
+	return relevantFiles;
+}
+
+/**
+ * Get file hash from index (useful for caching unchanged files)
+ */
+export async function getFileHashFromIndex(workDir: string, relPath: string): Promise<string | null> {
+	const index = await indexWorkspace(workDir);
+	const entry = index.files.get(relPath);
+	return entry?.hash ?? null;
+}
+
+/**
+ * Check if a file has changed based on index
+ */
+export async function hasFileChanged(workDir: string, relPath: string, expectedHash: string): Promise<boolean> {
+	const currentHash = await getFileHashFromIndex(workDir, relPath);
+	if (currentHash === null) {
+		return true; // File not in index, assume changed
+	}
+	return currentHash !== expectedHash;
+}
+
+/**
+ * Get file metadata from index
+ */
+export async function getFileMetadata(workDir: string, relPath: string): Promise<FileIndexEntry | null> {
+	const index = await indexWorkspace(workDir);
+	return index.files.get(relPath) ?? null;
+}
+
+/**
+ * Clear the file index cache (both memory and disk)
+ */
+export function clearFileIndexCache(workDir: string): void {
+	indexCache.delete(workDir);
+	const cachePath = getIndexCachePath(workDir);
+	try {
+		if (existsSync(cachePath)) {
+			rmSync(cachePath);
+		}
+	} catch (error) {
+		logDebug(`Failed to clear file index cache: ${error}`);
+	}
+}
+
+/**
+ * Get index statistics
+ */
+export async function getIndexStats(workDir: string): Promise<{
+	totalFiles: number;
+	totalSize: number;
+	avgFileSize: number;
+	lastUpdated: number;
+}> {
+	const index = await indexWorkspace(workDir);
+	return {
+		totalFiles: index.totalFiles,
+		totalSize: index.totalSize,
+		avgFileSize: index.totalFiles > 0 ? index.totalSize / index.totalFiles : 0,
+		lastUpdated: index.timestamp,
+	};
+}
+
+/**
+ * Force rebuild the file index
+ */
+export async function rebuildFileIndex(workDir: string): Promise<FileIndex> {
+	clearFileIndexCache(workDir);
+	return indexWorkspace(workDir, { forceRebuild: true });
+}
+
+/**
+ * Find files by keyword (simple search)
+ */
+export async function findFilesByKeyword(
+	workDir: string,
+	keyword: string,
+	options: { maxResults?: number } = {},
+): Promise<FileIndexEntry[]> {
+	const { maxResults = 20 } = options;
+	const index = await indexWorkspace(workDir);
+	const results: FileIndexEntry[] = [];
+	const lowerKeyword = keyword.toLowerCase();
+
+	for (const entry of index.files.values()) {
+		// Check if keyword is in path
+		if (entry.path.toLowerCase().includes(lowerKeyword)) {
+			results.push(entry);
+			continue;
+		}
+
+		// Check if keyword is in keywords
+		if (entry.keywords.some((k) => k.includes(lowerKeyword) || lowerKeyword.includes(k))) {
+			results.push(entry);
+			continue;
+		}
+
+		// Check preview for code files
+		if (entry.preview?.toLowerCase().includes(lowerKeyword)) {
+			results.push(entry);
+		}
+	}
+
+	return results.slice(0, maxResults);
+}

--- a/cli/src/utils/hooks.ts
+++ b/cli/src/utils/hooks.ts
@@ -1,0 +1,367 @@
+import { randomBytes } from "node:crypto";
+import type { AIResult } from "../engines/types.ts";
+import type { Task } from "../tasks/types.ts";
+import { logDebugContext, logErrorContext } from "../ui/logger.ts";
+
+/**
+ * Hook system for Ralphy CLI lifecycle events
+ *
+ * Provides a plugin-like mechanism for extending functionality
+ * without modifying core code. Supports:
+ * - Task lifecycle hooks (start, complete, fail)
+ * - Execution hooks (before, after)
+ * - Engine hooks (pre-execute, post-execute)
+ * - Custom hooks for user-defined extensions
+ */
+
+/**
+ * Hook context passed to all hook handlers
+ */
+export interface HookContext {
+	timestamp: number;
+	[key: string]: unknown;
+}
+
+/**
+ * Task start hook context
+ */
+export interface TaskStartContext extends HookContext {
+	task: Task;
+	workDir: string;
+	engine: string;
+}
+
+/**
+ * Task complete hook context
+ */
+export interface TaskCompleteContext extends HookContext {
+	task: Task;
+	result: AIResult;
+	workDir: string;
+	durationMs: number;
+}
+
+/**
+ * Task fail hook context
+ */
+export interface TaskFailContext extends HookContext {
+	task: Task;
+	error: Error | string;
+	workDir: string;
+	attempt: number;
+	maxAttempts: number;
+}
+
+/**
+ * Engine execute hook context
+ */
+export interface EngineExecuteContext extends HookContext {
+	engine: string;
+	prompt: string;
+	workDir: string;
+	options?: Record<string, unknown>;
+}
+
+/**
+ * Engine result hook context
+ */
+export interface EngineResultContext extends HookContext {
+	engine: string;
+	result: AIResult;
+	durationMs: number;
+}
+
+/**
+ * Hook handler type
+ */
+export type HookHandler<T extends HookContext> = (context: T) => Promise<void> | void;
+
+/**
+ * Available hook names
+ */
+export type HookName =
+	| "task:start"
+	| "task:complete"
+	| "task:fail"
+	| "task:skip"
+	| "engine:pre-execute"
+	| "engine:post-execute"
+	| "queue:enqueue"
+	| "queue:dequeue"
+	| "config:load"
+	| "config:save"
+	| "git:pre-commit"
+	| "git:post-commit"
+	| "notification:send";
+
+/**
+ * Hook registry entry
+ */
+interface HookEntry<T extends HookContext> {
+	name: string;
+	handler: HookHandler<T>;
+	priority: number;
+}
+
+/**
+ * Hook manager
+ */
+export class HookManager {
+	private hooks: Map<HookName, HookEntry<HookContext>[]> = new Map();
+	private enabled: boolean = true;
+
+	/**
+	 * Register a hook handler
+	 */
+	register<T extends HookContext>(
+		hookName: HookName,
+		handler: HookHandler<T>,
+		options?: { priority?: number; name?: string },
+	): () => void {
+		const entry: HookEntry<HookContext> = {
+			name: options?.name || `hook-${Date.now()}-${randomBytes(9).toString("base64url").slice(0, 12)}`,
+			handler: handler as HookHandler<HookContext>,
+			priority: options?.priority ?? 0,
+		};
+
+		const existing = this.hooks.get(hookName) || [];
+		existing.push(entry);
+
+		// Sort by priority (higher first)
+		existing.sort((a, b) => b.priority - a.priority);
+
+		this.hooks.set(hookName, existing);
+
+		logDebugContext("Hooks", `Registered hook: ${hookName} (${entry.name})`);
+
+		// Return unregister function
+		return () => {
+			const hooks = this.hooks.get(hookName) || [];
+			const index = hooks.findIndex((h) => h.name === entry.name);
+			if (index !== -1) {
+				hooks.splice(index, 1);
+				logDebugContext("Hooks", `Unregistered hook: ${hookName} (${entry.name})`);
+			}
+		};
+	}
+
+	/**
+	 * Execute all handlers for a hook
+	 */
+	async execute<T extends HookContext>(name: HookName, context: T): Promise<void> {
+		if (!this.enabled) {
+			return;
+		}
+
+		const hooks = this.hooks.get(name) || [];
+		if (hooks.length === 0) {
+			return;
+		}
+
+		logDebugContext("Hooks", `Executing ${hooks.length} hooks for: ${name}`);
+
+		for (const hook of hooks) {
+			try {
+				const result = hook.handler(context);
+				// Ensure we await async handlers
+				if (result instanceof Promise) {
+					await result;
+				}
+			} catch (error) {
+				logErrorContext("Hooks", `Hook ${hook.name} failed for ${name}: ${error}`);
+				// Continue with other hooks even if one fails
+			}
+		}
+	}
+
+	/**
+	 * Check if any hooks are registered for a name
+	 */
+	hasHooks(name: HookName): boolean {
+		const hooks = this.hooks.get(name);
+		return hooks !== undefined && hooks.length > 0;
+	}
+
+	/**
+	 * Get number of registered hooks for a name
+	 */
+	getHookCount(name: HookName): number {
+		return this.hooks.get(name)?.length || 0;
+	}
+
+	/**
+	 * Enable/disable all hooks
+	 */
+	setEnabled(enabled: boolean): void {
+		this.enabled = enabled;
+		logDebugContext("Hooks", `Hooks ${enabled ? "enabled" : "disabled"}`);
+	}
+
+	/**
+	 * Clear all hooks
+	 */
+	clear(): void {
+		this.hooks.clear();
+		logDebugContext("Hooks", "All hooks cleared");
+	}
+
+	/**
+	 * Get all registered hook names
+	 */
+	getRegisteredHooks(): HookName[] {
+		return Array.from(this.hooks.keys());
+	}
+}
+
+/**
+ * Global hook manager instance
+ */
+let globalHookManager: HookManager = new HookManager();
+
+/**
+ * Set global hook manager
+ */
+export function setHookManager(manager: HookManager): void {
+	globalHookManager = manager;
+}
+
+/**
+ * Get global hook manager
+ */
+export function getHookManager(): HookManager {
+	return globalHookManager;
+}
+
+/**
+ * Register a hook (convenience function)
+ */
+export function registerHook<T extends HookContext>(
+	name: HookName,
+	handler: HookHandler<T>,
+	options?: { priority?: number; name?: string },
+): () => void {
+	return globalHookManager.register(name, handler, options);
+}
+
+/**
+ * Execute hooks (convenience function)
+ */
+export async function executeHooks<T extends HookContext>(name: HookName, context: T): Promise<void> {
+	return globalHookManager.execute(name, context);
+}
+
+/**
+ * Create a plugin interface
+ */
+export interface RalphyPlugin {
+	/**
+	 * Plugin name
+	 */
+	name: string;
+
+	/**
+	 * Plugin version
+	 */
+	version: string;
+
+	/**
+	 * Initialize plugin - called when plugin is registered
+	 */
+	initialize?(): Promise<void> | void;
+
+	/**
+	 * Register hooks - called during plugin registration
+	 */
+	registerHooks(hookManager: HookManager): void;
+
+	/**
+	 * Shutdown plugin - called when plugin is unregistered
+	 */
+	shutdown?(): Promise<void> | void;
+}
+
+/**
+ * Plugin manager
+ */
+export class PluginManager {
+	private plugins: Map<string, RalphyPlugin> = new Map();
+	private hookManager: HookManager;
+
+	constructor(hookManager: HookManager) {
+		this.hookManager = hookManager;
+	}
+
+	/**
+	 * Register a plugin
+	 */
+	async register(plugin: RalphyPlugin): Promise<void> {
+		if (this.plugins.has(plugin.name)) {
+			throw new Error(`Plugin ${plugin.name} is already registered`);
+		}
+
+		// Initialize plugin with proper error handling
+		if (plugin.initialize) {
+			try {
+				await plugin.initialize();
+			} catch (error) {
+				logErrorContext("Plugins", `Plugin ${plugin.name} initialization failed: ${error}`);
+				throw error; // Re-throw to prevent registration of failed plugin
+			}
+		}
+
+		// Register hooks with error handling
+		try {
+			plugin.registerHooks(this.hookManager);
+		} catch (error) {
+			logErrorContext("Plugins", `Plugin ${plugin.name} hook registration failed: ${error}`);
+			throw error;
+		}
+
+		// Store plugin
+		this.plugins.set(plugin.name, plugin);
+
+		logDebugContext("Plugins", `Registered plugin: ${plugin.name} v${plugin.version}`);
+	}
+
+	/**
+	 * Unregister a plugin
+	 */
+	async unregister(pluginName: string): Promise<void> {
+		const plugin = this.plugins.get(pluginName);
+		if (!plugin) {
+			throw new Error(`Plugin ${pluginName} is not registered`);
+		}
+
+		// Shutdown plugin
+		if (plugin.shutdown) {
+			await plugin.shutdown();
+		}
+
+		this.plugins.delete(pluginName);
+
+		logDebugContext("Plugins", `Unregistered plugin: ${pluginName}`);
+	}
+
+	/**
+	 * Get registered plugin
+	 */
+	getPlugin(name: string): RalphyPlugin | undefined {
+		return this.plugins.get(name);
+	}
+
+	/**
+	 * Get all registered plugins
+	 */
+	getAllPlugins(): RalphyPlugin[] {
+		return Array.from(this.plugins.values());
+	}
+
+	/**
+	 * Check if plugin is registered
+	 */
+	hasPlugin(name: string): boolean {
+		return this.plugins.has(name);
+	}
+}
+
+// HookManager is already exported above

--- a/cli/src/utils/json-validation.ts
+++ b/cli/src/utils/json-validation.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+
+export const StepFinishSchema = z.object({
+	type: z.literal("step_finish"),
+	part: z
+		.object({
+			tokens: z
+				.object({
+					input: z.number().optional(),
+					output: z.number().optional(),
+				})
+				.optional(),
+			input: z.number().optional(),
+			output: z.number().optional(),
+			cost: z.number().optional(),
+		})
+		.optional(),
+	tokens: z
+		.object({
+			input: z.number().optional(),
+			output: z.number().optional(),
+		})
+		.optional(),
+	cost: z.number().optional(),
+	// Session ID fields (various naming conventions)
+	sessionID: z.string().optional(),
+	sessionId: z.string().optional(),
+	session_id: z.string().optional(),
+});
+
+export const StepStartSchema = z.object({
+	type: z.literal("step_start"),
+});
+
+export const TextSchema = z.object({
+	type: z.literal("text"),
+	part: z.object({
+		text: z.string(),
+	}),
+});
+
+export const ErrorSchema = z.object({
+	type: z.literal("error"),
+	error: z
+		.object({
+			message: z.string().optional(),
+		})
+		.optional(),
+	message: z.string().optional(),
+});
+
+export const ResultSchema = z.object({
+	type: z.literal("result"),
+	result: z.string().optional(),
+	usage: z
+		.object({
+			input_tokens: z.number().optional(),
+			output_tokens: z.number().optional(),
+		})
+		.optional(),
+});
+
+export const ToolUseSchema = z.object({
+	type: z.literal("tool_use"),
+	part: z
+		.object({
+			tool: z.string().optional(),
+			state: z
+				.object({
+					input: z
+						.union([z.string(), z.number(), z.boolean(), z.object({}).passthrough(), z.array(z.unknown())])
+						.optional(),
+					status: z.string().optional(),
+				})
+				.optional(),
+		})
+		.optional(),
+	tool: z.string().optional(),
+	callID: z.string().optional(),
+});
+
+export const StreamJsonEventSchema = z.union([
+	StepFinishSchema,
+	StepStartSchema,
+	TextSchema,
+	ErrorSchema,
+	ResultSchema,
+	ToolUseSchema,
+]);
+
+export type StreamJsonEvent = z.infer<typeof StreamJsonEventSchema>;
+export type StepFinish = z.infer<typeof StepFinishSchema>;
+export type TextEvent = z.infer<typeof TextSchema>;
+export type ToolUseEvent = z.infer<typeof ToolUseSchema>;
+
+/**
+ * Safely parse a JSON line with schema validation
+ * Returns null if parsing fails or schema is invalid
+ *
+ * This function handles:
+ * - Complete JSON objects
+ * - JSON followed by additional text (splits at proper object boundary)
+ * - Truncated JSON (attempts to recover)
+ * - Special characters in strings (properly handles escape sequences)
+ */
+export function parseJsonLine(line: string): { event: StreamJsonEvent; remaining?: string } | null {
+	try {
+		const trimmed = line.trim();
+		if (!trimmed) return null;
+
+		// Handle cases where JSON is followed by text without a newline
+		// Search for the end of the JSON object
+		let jsonStr = trimmed;
+		let remaining: string | undefined;
+
+		if (trimmed.startsWith("{")) {
+			let depth = 0;
+			let inString = false;
+			let isEscaped = false;
+			let jsonEndIndex = -1;
+
+			for (let i = 0; i < trimmed.length; i++) {
+				const char = trimmed[i];
+				if (isEscaped) {
+					isEscaped = false;
+					continue;
+				}
+				if (char === "\\") {
+					isEscaped = true;
+					continue;
+				}
+				if (char === '"' && !isEscaped) {
+					inString = !inString;
+					continue;
+				}
+				if (!inString) {
+					if (char === "{") depth++;
+					if (char === "}") {
+						depth--;
+						if (depth === 0) {
+							jsonEndIndex = i;
+							break;
+						}
+					}
+				}
+			}
+
+			// If we found a complete JSON object, split it from any remaining text
+			if (jsonEndIndex >= 0) {
+				jsonStr = trimmed.substring(0, jsonEndIndex + 1);
+				remaining = trimmed.substring(jsonEndIndex + 1).trim();
+			}
+			// If we didn't find a complete object but started with '{',
+			// it might be truncated - still try to parse what we have
+		}
+
+		const parsed = JSON.parse(jsonStr);
+		const event = StreamJsonEventSchema.parse(parsed);
+		return { event, remaining: remaining || undefined };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Extract session ID from a parsed JSON event
+ */
+export function extractSessionId(event: StreamJsonEvent): string | null {
+	if ("sessionID" in event && typeof event.sessionID === "string") {
+		return event.sessionID;
+	}
+	if ("sessionId" in event && typeof event.sessionId === "string") {
+		return event.sessionId;
+	}
+	if ("session_id" in event && typeof event.session_id === "string") {
+		return event.session_id;
+	}
+	return null;
+}

--- a/cli/src/utils/metrics.ts
+++ b/cli/src/utils/metrics.ts
@@ -1,0 +1,449 @@
+/**
+ * Metrics and Tracing System for Ralphy CLI
+ *
+ * Provides observability with:
+ * - Metrics collection (counters, gauges, histograms)
+ * - Distributed tracing (OpenTelemetry-style spans)
+ * - Multiple exporters (console, file, Prometheus)
+ */
+
+import { randomBytes } from "node:crypto";
+import { logDebugContext } from "../ui/logger.ts";
+
+/**
+ * Metric types
+ */
+export type MetricType = "counter" | "gauge" | "histogram";
+
+/**
+ * Metric value
+ */
+export type MetricValue = number | Record<string, number> | HistogramValue;
+
+/**
+ * Metric labels/tags
+ */
+export interface MetricLabels {
+	[key: string]: string | number | boolean;
+}
+
+/**
+ * Metric definition
+ */
+export interface Metric {
+	name: string;
+	type: MetricType;
+	description: string;
+	unit?: string;
+	labels?: MetricLabels;
+	value: MetricValue;
+	timestamp: number;
+}
+
+/**
+ * Histogram bucket
+ */
+export interface HistogramBucket {
+	le: number; // less than or equal
+	count: number;
+}
+
+/**
+ * Histogram value
+ */
+export interface HistogramValue {
+	count: number;
+	sum: number;
+	buckets: HistogramBucket[];
+}
+
+/**
+ * Span context for distributed tracing
+ */
+export interface SpanContext {
+	traceId: string;
+	spanId: string;
+	parentSpanId?: string;
+	sampled: boolean;
+}
+
+/**
+ * Span status
+ */
+export type SpanStatus = "unset" | "ok" | "error";
+
+/**
+ * Span event
+ */
+export interface SpanEvent {
+	timestamp: number;
+	name: string;
+	attributes?: Record<string, unknown>;
+}
+
+/**
+ * Span representation
+ */
+export interface Span {
+	context: SpanContext;
+	name: string;
+	startTime: number;
+	endTime?: number;
+	status: SpanStatus;
+	attributes: Record<string, unknown>;
+	events: SpanEvent[];
+	links?: SpanContext[];
+}
+
+/**
+ * Metrics collector interface
+ */
+export interface MetricsCollector {
+	/**
+	 * Increment a counter metric
+	 */
+	counter(name: string, value?: number, labels?: MetricLabels): void;
+
+	/**
+	 * Set a gauge metric value
+	 */
+	gauge(name: string, value: number, labels?: MetricLabels): void;
+
+	/**
+	 * Record a histogram observation
+	 */
+	histogram(name: string, value: number, labels?: MetricLabels): void;
+
+	/**
+	 * Get all collected metrics
+	 */
+	getMetrics(): Metric[];
+
+	/**
+	 * Clear all metrics
+	 */
+	clear(): void;
+}
+
+/**
+ * Tracer interface
+ */
+export interface Tracer {
+	/**
+	 * Start a new span
+	 */
+	startSpan(name: string, parentContext?: SpanContext, attributes?: Record<string, unknown>): Span;
+
+	/**
+	 * End a span
+	 */
+	endSpan(span: Span, status?: SpanStatus): void;
+
+	/**
+	 * Add event to span
+	 */
+	addEvent(span: Span, name: string, attributes?: Record<string, unknown>): void;
+
+	/**
+	 * Get active span
+	 */
+	getActiveSpan(): Span | null;
+
+	/**
+	 * Set active span
+	 */
+	setActiveSpan(span: Span | null): void;
+}
+
+/**
+ * Exporter interface for metrics and traces
+ */
+export interface Exporter {
+	/**
+	 * Export metrics
+	 */
+	exportMetrics(metrics: Metric[]): Promise<void>;
+
+	/**
+	 * Export spans
+	 */
+	exportSpans(spans: Span[]): Promise<void>;
+
+	/**
+	 * Shutdown exporter
+	 */
+	shutdown(): Promise<void>;
+}
+
+/**
+ * In-memory metrics collector implementation
+ */
+class InMemoryMetricsCollector implements MetricsCollector {
+	private metrics: Map<string, Metric> = new Map();
+	private histogramBuckets: Map<string, number[]> = new Map();
+	private static readonly MAX_HISTOGRAM_SAMPLES = 10000;
+
+	counter(name: string, value = 1, labels?: MetricLabels): void {
+		const key = this.getMetricKey(name, labels);
+		const existing = this.metrics.get(key);
+
+		if (existing && existing.type === "counter") {
+			existing.value = (existing.value as number) + value;
+		} else {
+			this.metrics.set(key, {
+				name,
+				type: "counter",
+				description: `Counter metric: ${name}`,
+				labels,
+				value,
+				timestamp: Date.now(),
+			});
+		}
+
+		logDebugContext("Metrics", `Counter ${name}: +${value}`);
+	}
+
+	gauge(name: string, value: number, labels?: MetricLabels): void {
+		const key = this.getMetricKey(name, labels);
+
+		this.metrics.set(key, {
+			name,
+			type: "gauge",
+			description: `Gauge metric: ${name}`,
+			labels,
+			value,
+			timestamp: Date.now(),
+		});
+
+		logDebugContext("Metrics", `Gauge ${name}: ${value}`);
+	}
+
+	histogram(name: string, value: number, labels?: MetricLabels): void {
+		const key = this.getMetricKey(name, labels);
+		const bucketKey = `${key}_buckets`;
+
+		// Store raw values for histogram calculation (capped)
+		const buckets = this.histogramBuckets.get(bucketKey) || [];
+		buckets.push(value);
+		if (buckets.length > InMemoryMetricsCollector.MAX_HISTOGRAM_SAMPLES) {
+			buckets.shift();
+		}
+		this.histogramBuckets.set(bucketKey, buckets);
+
+		// Calculate histogram stats
+		const sum = buckets.reduce((a, b) => a + b, 0);
+		const sorted = [...buckets].sort((a, b) => a - b);
+
+		// Create default buckets: 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+		const bucketBoundaries = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+		const histogramBuckets: HistogramBucket[] = bucketBoundaries.map((le) => ({
+			le,
+			count: sorted.filter((v) => v <= le).length,
+		}));
+		// Add +Inf bucket
+		histogramBuckets.push({ le: Infinity, count: buckets.length });
+
+		const histogramValue: HistogramValue = {
+			count: buckets.length,
+			sum,
+			buckets: histogramBuckets,
+		};
+
+		this.metrics.set(key, {
+			name,
+			type: "histogram",
+			description: `Histogram metric: ${name}`,
+			labels,
+			value: histogramValue,
+			timestamp: Date.now(),
+		});
+
+		logDebugContext("Metrics", `Histogram ${name}: ${value}`);
+	}
+
+	getMetrics(): Metric[] {
+		return Array.from(this.metrics.values());
+	}
+
+	clear(): void {
+		this.metrics.clear();
+		this.histogramBuckets.clear();
+	}
+
+	private getMetricKey(name: string, labels?: MetricLabels): string {
+		if (!labels || Object.keys(labels).length === 0) {
+			return name;
+		}
+		const labelStr = Object.entries(labels)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([k, v]) => `${k}=${v}`)
+			.join(",");
+		return `${name}{${labelStr}}`;
+	}
+}
+
+/**
+ * Simple tracer implementation
+ */
+class SimpleTracer implements Tracer {
+	private spans: Span[] = [];
+	private activeSpan: Span | null = null;
+	private idCounter = 0;
+
+	startSpan(name: string, parentContext?: SpanContext, attributes?: Record<string, unknown>): Span {
+		const spanId = this.generateId();
+		const traceId = parentContext?.traceId || this.generateId();
+
+		const span: Span = {
+			context: {
+				traceId,
+				spanId,
+				parentSpanId: parentContext?.spanId,
+				sampled: parentContext?.sampled ?? true,
+			},
+			name,
+			startTime: Date.now(),
+			status: "unset",
+			attributes: attributes || {},
+			events: [],
+		};
+
+		this.spans.push(span);
+		logDebugContext("Tracer", `Started span: ${name} (${spanId})`);
+
+		return span;
+	}
+
+	endSpan(span: Span, status: SpanStatus = "ok"): void {
+		span.endTime = Date.now();
+		span.status = status;
+		logDebugContext("Tracer", `Ended span: ${span.name} (${span.context.spanId}) - ${status}`);
+	}
+
+	addEvent(span: Span, name: string, attributes?: Record<string, unknown>): void {
+		span.events.push({
+			timestamp: Date.now(),
+			name,
+			attributes,
+		});
+		logDebugContext("Tracer", `Event in ${span.name}: ${name}`);
+	}
+
+	getActiveSpan(): Span | null {
+		return this.activeSpan;
+	}
+
+	setActiveSpan(span: Span | null): void {
+		this.activeSpan = span;
+	}
+
+	getSpans(): Span[] {
+		return this.spans;
+	}
+
+	private generateId(): string {
+		return `${Date.now().toString(36)}-${(++this.idCounter).toString(36)}-${randomBytes(9).toString("base64url").slice(0, 12)}`;
+	}
+}
+
+/**
+ * Global metrics collector instance
+ */
+let globalMetricsCollector: MetricsCollector = new InMemoryMetricsCollector();
+
+/**
+ * Global tracer instance
+ */
+let globalTracer: Tracer = new SimpleTracer();
+
+/**
+ * Set global metrics collector
+ */
+export function setMetricsCollector(collector: MetricsCollector): void {
+	globalMetricsCollector = collector;
+}
+
+/**
+ * Get global metrics collector
+ */
+export function getMetricsCollector(): MetricsCollector {
+	return globalMetricsCollector;
+}
+
+/**
+ * Set global tracer
+ */
+export function setTracer(tracer: Tracer): void {
+	globalTracer = tracer;
+}
+
+/**
+ * Get global tracer
+ */
+export function getTracer(): Tracer {
+	return globalTracer;
+}
+
+/**
+ * Record a counter metric (convenience function)
+ */
+export function recordCounter(name: string, value = 1, labels?: MetricLabels): void {
+	globalMetricsCollector.counter(name, value, labels);
+}
+
+/**
+ * Record a gauge metric (convenience function)
+ */
+export function recordGauge(name: string, value: number, labels?: MetricLabels): void {
+	globalMetricsCollector.gauge(name, value, labels);
+}
+
+/**
+ * Record a histogram observation (convenience function)
+ */
+export function recordHistogram(name: string, value: number, labels?: MetricLabels): void {
+	globalMetricsCollector.histogram(name, value, labels);
+}
+
+/**
+ * Start a span (convenience function)
+ */
+export function startSpan(name: string, parentContext?: SpanContext, attributes?: Record<string, unknown>): Span {
+	return globalTracer.startSpan(name, parentContext, attributes);
+}
+
+/**
+ * End a span (convenience function)
+ */
+export function endSpan(span: Span, status?: SpanStatus): void {
+	globalTracer.endSpan(span, status);
+}
+
+/**
+ * Run function within a span
+ */
+export async function withSpan<T>(
+	name: string,
+	fn: (span: Span) => Promise<T>,
+	parentContext?: SpanContext,
+	attributes?: Record<string, unknown>,
+): Promise<T> {
+	const span = startSpan(name, parentContext, attributes);
+	const prevActive = globalTracer.getActiveSpan();
+	globalTracer.setActiveSpan(span);
+
+	try {
+		const result = await fn(span);
+		endSpan(span, "ok");
+		return result;
+	} catch (error) {
+		endSpan(span, "error");
+		span.attributes.error = error instanceof Error ? error.message : String(error);
+		throw error;
+	} finally {
+		globalTracer.setActiveSpan(prevActive);
+	}
+}
+
+// Re-export types
+export { InMemoryMetricsCollector, SimpleTracer };

--- a/cli/src/utils/opencode-parser.ts
+++ b/cli/src/utils/opencode-parser.ts
@@ -1,0 +1,772 @@
+/**
+ * OpenCode JSON Stream Parser
+ *
+ * Parses OpenCode's JSON output format and provides:
+ * - Event type detection and classification
+ * - Human-readable descriptions for UI display
+ * - Filtering capabilities by event type, tool, status, etc.
+ * - Session reconstruction from log files
+ */
+
+import { z } from "zod";
+
+// =============================================================================
+// Zod Schemas for OpenCode Events
+// =============================================================================
+
+export const ToolStateSchema = z.object({
+	status: z.string(),
+	input: z.any().optional(),
+	output: z.any().optional(),
+	title: z.string().optional(),
+	metadata: z.record(z.any()).optional(),
+	time: z
+		.object({
+			start: z.number(),
+			end: z.number(),
+		})
+		.optional(),
+});
+
+export const ToolUsePartSchema = z.object({
+	id: z.string(),
+	sessionID: z.string(),
+	messageID: z.string(),
+	type: z.literal("tool"),
+	callID: z.string(),
+	tool: z.string(),
+	state: ToolStateSchema,
+	metadata: z.record(z.any()).optional(),
+});
+
+export const ToolUseEventSchema = z.object({
+	type: z.literal("tool_use"),
+	timestamp: z.number(),
+	sessionID: z.string(),
+	part: ToolUsePartSchema,
+});
+
+export const StepStartPartSchema = z.object({
+	id: z.string(),
+	sessionID: z.string(),
+	messageID: z.string(),
+	type: z.literal("step-start"),
+	snapshot: z.string(),
+});
+
+export const StepStartEventSchema = z.object({
+	type: z.literal("step_start"),
+	timestamp: z.number(),
+	sessionID: z.string(),
+	part: StepStartPartSchema,
+});
+
+export const StepFinishPartSchema = z.object({
+	id: z.string(),
+	sessionID: z.string(),
+	messageID: z.string(),
+	type: z.literal("step-finish"),
+	reason: z.string(),
+	snapshot: z.string(),
+	cost: z.number().optional(),
+	tokens: z
+		.object({
+			input: z.number(),
+			output: z.number(),
+			reasoning: z.number().optional(),
+			cache: z
+				.object({
+					read: z.number(),
+					write: z.number(),
+				})
+				.optional(),
+		})
+		.optional(),
+});
+
+export const StepFinishEventSchema = z.object({
+	type: z.literal("step_finish"),
+	timestamp: z.number(),
+	sessionID: z.string(),
+	part: StepFinishPartSchema,
+});
+
+export const TextPartSchema = z.object({
+	text: z.string(),
+});
+
+export const TextEventSchema = z.object({
+	type: z.literal("text"),
+	part: TextPartSchema,
+});
+
+export const ErrorEventSchema = z.object({
+	type: z.literal("error"),
+	error: z
+		.object({
+			message: z.string(),
+		})
+		.optional(),
+	message: z.string().optional(),
+});
+
+export const OpenCodeEventSchema = z.union([
+	ToolUseEventSchema,
+	StepStartEventSchema,
+	StepFinishEventSchema,
+	TextEventSchema,
+	ErrorEventSchema,
+]);
+
+// Type exports from schemas
+export type ToolState = z.infer<typeof ToolStateSchema>;
+export type ToolUsePart = z.infer<typeof ToolUsePartSchema>;
+export type ToolUseEvent = z.infer<typeof ToolUseEventSchema>;
+export type StepStartEvent = z.infer<typeof StepStartEventSchema>;
+export type StepFinishEvent = z.infer<typeof StepFinishEventSchema>;
+export type TextEvent = z.infer<typeof TextEventSchema>;
+export type ErrorEvent = z.infer<typeof ErrorEventSchema>;
+export type OpenCodeEvent = z.infer<typeof OpenCodeEventSchema>;
+
+// =============================================================================
+// Extended Type Definitions
+// =============================================================================
+
+export type EventType = "tool_use" | "step_start" | "step_finish" | "text" | "error" | "plan" | "thinking" | "unknown";
+
+// Tool types supported by OpenCode/Kimi
+export type ToolType = "read" | "write" | "edit" | "glob" | "grep" | "bash" | "list" | "search" | "analyze" | string;
+
+// Tool status types
+export type ToolStatus = "completed" | "failed" | "in_progress" | "pending";
+
+// File operation metadata
+export interface FileOperation {
+	filePath?: string;
+	file_path?: string;
+	path?: string;
+	pattern?: string;
+	query?: string;
+	command?: string;
+	content?: string;
+	old_string?: string;
+	new_string?: string;
+}
+
+// Extended tool state interface for runtime use (compatible with Zod schema)
+export interface ExtendedToolState extends ToolState {
+	metadata?: {
+		count?: number;
+		truncated?: boolean;
+		preview?: string;
+		lines?: number;
+		bytes?: number;
+	};
+}
+
+// Enhanced tool use event for runtime processing
+export interface EnhancedToolUseEvent extends ToolUseEvent {
+	part: ToolUsePart & {
+		metadata?: Record<string, unknown>;
+	};
+}
+
+export interface ParsedEvent {
+	/** Original raw line */
+	raw: string;
+	/** Parsed event data */
+	event: OpenCodeEvent | null;
+	/** Event type classification */
+	eventType: EventType;
+	/** Whether parsing succeeded */
+	isValid: boolean;
+	/** Error message if parsing failed */
+	parseError?: string;
+	/** Line number in source file */
+	lineNumber?: number;
+}
+
+export interface ToolUseDetails {
+	tool: ToolType;
+	status: string;
+	description: string;
+	filePath?: string;
+	pattern?: string;
+	command?: string;
+	duration?: number;
+	output?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface StepDetails {
+	stepId: string;
+	sessionId: string;
+	reason?: string;
+	tokens?: {
+		input: number;
+		output: number;
+		reasoning?: number;
+		cache?: { read: number; write: number };
+	};
+	cost?: number;
+	duration?: number;
+}
+
+// =============================================================================
+// Event Detection & Classification
+// =============================================================================
+
+/**
+ * Detect event type from a JSON object
+ */
+export function detectEventType(obj: unknown): EventType {
+	if (typeof obj !== "object" || obj === null) {
+		return "unknown";
+	}
+
+	const type = (obj as Record<string, unknown>).type;
+	if (typeof type !== "string") {
+		return "unknown";
+	}
+
+	switch (type) {
+		case "tool_use":
+			return "tool_use";
+		case "step_start":
+			return "step_start";
+		case "step_finish":
+			return "step_finish";
+		case "text":
+			return "text";
+		case "error":
+			return "error";
+		default:
+			return "unknown";
+	}
+}
+
+/**
+ * Detect tool type from tool_use event
+ */
+export function detectToolType(event: ToolUseEvent): ToolType {
+	return event.part.tool || "unknown";
+}
+
+/**
+ * Get tool use details for UI display
+ */
+export function getToolUseDetails(event: ToolUseEvent): ToolUseDetails {
+	const part = event.part;
+	const state = part.state;
+	const tool = part.tool;
+
+	let description = `${tool}: `;
+	let filePath: string | undefined;
+	let pattern: string | undefined;
+	let command: string | undefined;
+
+	switch (tool) {
+		case "read":
+			filePath = state.input?.filePath || state.input?.file_path;
+			description += `Reading ${filePath ? truncatePath(filePath) : "file"}`;
+			break;
+		case "write":
+			filePath = state.input?.filePath || state.input?.file_path;
+			description += `Writing ${filePath ? truncatePath(filePath) : "file"}`;
+			break;
+		case "edit":
+			filePath = state.input?.filePath || state.input?.file_path;
+			description += `Editing ${filePath ? truncatePath(filePath) : "file"}`;
+			break;
+		case "glob":
+			pattern = state.input?.pattern;
+			description += `Searching pattern "${pattern || "unknown"}"`;
+			break;
+		case "grep":
+			pattern = state.input?.pattern || state.input?.query;
+			description += `Grep "${pattern || "unknown"}"`;
+			break;
+		case "bash":
+			command = state.input?.command;
+			description += `Running: ${command ? truncateCommand(command) : "shell command"}`;
+			break;
+		case "list":
+			filePath = state.input?.path;
+			description += `Listing directory ${filePath || "."}`;
+			break;
+		default:
+			description += `Executing ${tool}`;
+	}
+
+	if (state.status === "completed") {
+		description += " ✓";
+	} else if (state.status === "failed") {
+		description += " ✗";
+	} else if (state.status === "in_progress") {
+		description += " ...";
+	}
+
+	const duration = state.time ? state.time.end - state.time.start : undefined;
+
+	return {
+		tool,
+		status: state.status,
+		description,
+		filePath,
+		pattern,
+		command,
+		duration,
+		output: typeof state.output === "string" ? state.output : undefined,
+		metadata: state.metadata,
+	};
+}
+
+/**
+ * Get step details for UI display
+ */
+export function getStepDetails(event: StepStartEvent | StepFinishEvent): StepDetails {
+	const isFinish = event.type === "step_finish";
+	const part = event.part;
+
+	return {
+		stepId: part.id,
+		sessionId: part.sessionID,
+		reason: isFinish ? (event as StepFinishEvent).part.reason : undefined,
+		tokens: isFinish ? (event as StepFinishEvent).part.tokens : undefined,
+		cost: isFinish ? (event as StepFinishEvent).part.cost : undefined,
+	};
+}
+
+// =============================================================================
+// Parsing Functions
+// =============================================================================
+
+/**
+ * Parse a single line of OpenCode JSON output
+ */
+export function parseOpenCodeLine(line: string, lineNumber?: number): ParsedEvent {
+	const trimmed = line.trim();
+
+	if (!trimmed) {
+		return {
+			raw: line,
+			event: null,
+			eventType: "unknown",
+			isValid: false,
+			lineNumber,
+		};
+	}
+
+	// Handle [RAW OPENCODE OUTPUT] prefix
+	const prefix = "[RAW OPENCODE OUTPUT] ";
+	const jsonStr = trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed;
+
+	try {
+		const obj = JSON.parse(jsonStr);
+		const eventType = detectEventType(obj);
+
+		// Validate with Zod schema
+		const parseResult = OpenCodeEventSchema.safeParse(obj);
+
+		if (parseResult.success) {
+			return {
+				raw: line,
+				event: parseResult.data,
+				eventType,
+				isValid: true,
+				lineNumber,
+			};
+		}
+
+		// If Zod validation fails but we have a valid type, still return it
+		if (eventType !== "unknown") {
+			return {
+				raw: line,
+				event: obj as OpenCodeEvent,
+				eventType,
+				isValid: true,
+				lineNumber,
+			};
+		}
+
+		return {
+			raw: line,
+			event: obj as OpenCodeEvent,
+			eventType: "unknown",
+			isValid: false,
+			parseError: parseResult.error?.message,
+			lineNumber,
+		};
+	} catch (error) {
+		return {
+			raw: line,
+			event: null,
+			eventType: "unknown",
+			isValid: false,
+			parseError: error instanceof Error ? error.message : "Unknown parse error",
+			lineNumber,
+		};
+	}
+}
+
+/**
+ * Parse entire OpenCode log content
+ */
+export function parseOpenCodeLog(content: string): ParsedEvent[] {
+	const lines = content.split("\n");
+	return lines.map((line, index) => parseOpenCodeLine(line, index + 1));
+}
+
+// =============================================================================
+// Filtering Functions
+// =============================================================================
+
+export interface FilterOptions {
+	/** Filter by event types */
+	eventTypes?: EventType[];
+	/** Filter by tool types (for tool_use events) */
+	tools?: ToolType[];
+	/** Filter by tool status */
+	status?: string[];
+	/** Include only events with errors */
+	onlyErrors?: boolean;
+	/** Filter by session ID */
+	sessionId?: string;
+	/** Filter by file path (for read/write/edit events) */
+	filePath?: string;
+	/** Search in output/content */
+	searchText?: string;
+}
+
+/**
+ * Filter parsed events based on options
+ */
+export function filterEvents(events: ParsedEvent[], options: FilterOptions): ParsedEvent[] {
+	return events.filter((parsed) => {
+		if (!parsed.isValid || !parsed.event) {
+			return false;
+		}
+
+		// Filter by event type
+		if (options.eventTypes && options.eventTypes.length > 0) {
+			if (!options.eventTypes.includes(parsed.eventType)) {
+				return false;
+			}
+		}
+
+		// Filter by session ID
+		if (options.sessionId) {
+			const event = parsed.event as Record<string, unknown>;
+			if (event.sessionID !== options.sessionId && event.sessionId !== options.sessionId) {
+				return false;
+			}
+		}
+
+		// Filter tool_use events
+		if (parsed.eventType === "tool_use") {
+			const toolEvent = parsed.event as ToolUseEvent;
+
+			// Filter by tool type
+			if (options.tools && options.tools.length > 0) {
+				if (!options.tools.includes(toolEvent.part.tool)) {
+					return false;
+				}
+			}
+
+			// Filter by status
+			if (options.status && options.status.length > 0) {
+				if (!options.status.includes(toolEvent.part.state.status)) {
+					return false;
+				}
+			}
+
+			// Filter by file path
+			const filterPath = options.filePath;
+			if (filterPath) {
+				const input = toolEvent.part.state.input || {};
+				const filePaths = [input.filePath, input.file_path, input.path, input.pattern].filter(Boolean);
+
+				if (!filePaths.some((fp) => fp?.includes(filterPath))) {
+					return false;
+				}
+			}
+		}
+
+		// Filter errors
+		if (options.onlyErrors) {
+			if (parsed.eventType === "error") {
+				return true;
+			}
+			if (parsed.eventType === "tool_use") {
+				const toolEvent = parsed.event as ToolUseEvent;
+				if (toolEvent.part.state.status !== "failed") {
+					return false;
+				}
+			}
+		}
+
+		// Search text
+		if (options.searchText) {
+			const searchLower = options.searchText.toLowerCase();
+			const textToSearch = parsed.raw.toLowerCase();
+			if (!textToSearch.includes(searchLower)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+}
+
+// =============================================================================
+// Formatting Utilities
+// =============================================================================
+
+/**
+ * Truncate a file path for display
+ */
+function truncatePath(path: string, maxLength: number = 40): string {
+	if (path.length <= maxLength) return path;
+	const parts = path.split(/[/\\]/);
+	if (parts.length <= 2) return `...${path.slice(-maxLength + 3)}`;
+	return `.../${parts.slice(-2).join("/")}`;
+}
+
+/**
+ * Truncate a command for display
+ */
+function truncateCommand(command: string, maxLength: number = 50): string {
+	if (command.length <= maxLength) return command;
+	return `${command.slice(0, maxLength - 3)}...`;
+}
+
+/**
+ * Format duration in milliseconds to human readable string
+ */
+export function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+	return `${(ms / 60000).toFixed(1)}m`;
+}
+
+/**
+ * Format token count with commas
+ */
+export function formatTokens(count: number): string {
+	return count.toLocaleString();
+}
+
+/**
+ * Get a human-readable summary of a parsed event for UI display
+ */
+export function getEventSummary(parsed: ParsedEvent): string {
+	if (!parsed.isValid || !parsed.event) {
+		return "Invalid or unparsable line";
+	}
+
+	switch (parsed.eventType) {
+		case "tool_use": {
+			const details = getToolUseDetails(parsed.event as ToolUseEvent);
+			return details.description;
+		}
+		case "step_start": {
+			const details = getStepDetails(parsed.event as StepStartEvent);
+			return `Step started (${truncateId(details.stepId)})`;
+		}
+		case "step_finish": {
+			const details = getStepDetails(parsed.event as StepFinishEvent);
+			let summary = `Step finished (${truncateId(details.stepId)})`;
+			if (details.tokens) {
+				summary += ` - ${formatTokens(details.tokens.input)} → ${formatTokens(details.tokens.output)} tokens`;
+			}
+			if (details.cost !== undefined) {
+				summary += ` - $${details.cost.toFixed(4)}`;
+			}
+			return summary;
+		}
+		case "text": {
+			const text = (parsed.event as TextEvent).part.text;
+			// Check for structured content sections
+			const structuredSummary = extractStructuredSummary(text);
+			if (structuredSummary) {
+				return structuredSummary;
+			}
+			return truncateText(text, 60);
+		}
+		case "error": {
+			const error = parsed.event as ErrorEvent;
+			return `Error: ${error.message || error.error?.message || "Unknown error"}`;
+		}
+		default:
+			return "Unknown event type";
+	}
+}
+
+/**
+ * Truncate text with ellipsis
+ */
+function truncateText(text: string, maxLength: number): string {
+	if (text.length <= maxLength) return text;
+	return `${text.slice(0, maxLength - 3)}...`;
+}
+
+/**
+ * Extract a summary from structured text content with sections like <ANALYSIS>, <PLAN>, <FILES>, <OPTIMIZATION>
+ */
+export function extractStructuredSummary(text: string): string | null {
+	// Check for structured sections
+	const hasAnalysis = text.includes("<ANALYSIS>");
+	const hasPlan = text.includes("<PLAN>");
+	const hasFiles = text.includes("<FILES>");
+	const hasOptimization = text.includes("<OPTIMIZATION>");
+
+	if (!hasAnalysis && !hasPlan && !hasFiles && !hasOptimization) {
+		return null;
+	}
+
+	const parts: string[] = [];
+
+	// Extract problem from ANALYSIS section
+	if (hasAnalysis) {
+		const problemMatch = text.match(/<ANALYSIS>\s*\n?\s*-\s*Problem:\s*([^\n]+)/i);
+		if (problemMatch) {
+			parts.push(`ANALYSIS: ${problemMatch[1].trim()}`);
+		}
+	}
+
+	// Extract plan steps count
+	if (hasPlan) {
+		const planSteps = text.match(/\d+\./g);
+		if (planSteps) {
+			parts.push(`PLAN: ${planSteps.length} steps`);
+		}
+	}
+
+	// Extract file count
+	if (hasFiles) {
+		const fileMatches = text.match(/[\w/]+\.(gd|cs|ts|js|py|yaml|json|md|txt)/gi);
+		if (fileMatches) {
+			const uniqueFiles = new Set(fileMatches);
+			parts.push(`FILES: ${uniqueFiles.size} files`);
+		}
+	}
+
+	// Extract optimization approach
+	if (hasOptimization) {
+		const approachMatch = text.match(/-\s*Most efficient approach:\s*([^\n]+)/i);
+		if (approachMatch) {
+			parts.push(`OPTIMIZATION: ${approachMatch[1].trim()}`);
+		}
+	}
+
+	return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+/**
+ * Truncate ID for display
+ */
+function truncateId(id: string): string {
+	if (id.length <= 12) return id;
+	return `${id.slice(0, 6)}...${id.slice(-6)}`;
+}
+
+// =============================================================================
+// Session Analysis
+// =============================================================================
+
+export interface SessionSummary {
+	sessionId: string;
+	startTime?: number;
+	endTime?: number;
+	stepCount: number;
+	toolUseCount: number;
+	totalTokens: { input: number; output: number; reasoning?: number };
+	totalCost: number;
+	toolsUsed: Map<ToolType, number>;
+	errors: string[];
+}
+
+/**
+ * Analyze a session from parsed events
+ */
+export function analyzeSession(events: ParsedEvent[], sessionId: string): SessionSummary {
+	const summary: SessionSummary = {
+		sessionId,
+		stepCount: 0,
+		toolUseCount: 0,
+		totalTokens: { input: 0, output: 0, reasoning: 0 },
+		totalCost: 0,
+		toolsUsed: new Map(),
+		errors: [],
+	};
+
+	for (const parsed of events) {
+		if (!parsed.isValid || !parsed.event) continue;
+
+		// Check if event belongs to this session
+		const event = parsed.event as Record<string, unknown>;
+		if (event.sessionID !== sessionId && event.sessionId !== sessionId) {
+			continue;
+		}
+
+		// Track timestamps
+		if (typeof event.timestamp === "number") {
+			if (!summary.startTime || event.timestamp < summary.startTime) {
+				summary.startTime = event.timestamp;
+			}
+			if (!summary.endTime || event.timestamp > summary.endTime) {
+				summary.endTime = event.timestamp;
+			}
+		}
+
+		switch (parsed.eventType) {
+			case "step_start":
+				summary.stepCount++;
+				break;
+			case "step_finish": {
+				const finishEvent = parsed.event as StepFinishEvent;
+				if (finishEvent.part.tokens) {
+					summary.totalTokens.input += finishEvent.part.tokens.input || 0;
+					summary.totalTokens.output += finishEvent.part.tokens.output || 0;
+					summary.totalTokens.reasoning =
+						(summary.totalTokens.reasoning || 0) + (finishEvent.part.tokens.reasoning || 0);
+				}
+				if (finishEvent.part.cost !== undefined) {
+					summary.totalCost += finishEvent.part.cost;
+				}
+				break;
+			}
+			case "tool_use": {
+				summary.toolUseCount++;
+				const toolEvent = parsed.event as ToolUseEvent;
+				const tool = toolEvent.part.tool;
+				summary.toolsUsed.set(tool, (summary.toolsUsed.get(tool) || 0) + 1);
+				break;
+			}
+			case "error": {
+				const errorEvent = parsed.event as ErrorEvent;
+				summary.errors.push(errorEvent.message || errorEvent.error?.message || "Unknown error");
+				break;
+			}
+		}
+	}
+
+	return summary;
+}
+
+/**
+ * Extract all session IDs from parsed events
+ */
+export function extractSessionIds(events: ParsedEvent[]): string[] {
+	const ids = new Set<string>();
+	for (const parsed of events) {
+		if (parsed.isValid && parsed.event) {
+			const event = parsed.event as Record<string, unknown>;
+			const sessionId = event.sessionID || event.sessionId;
+			if (typeof sessionId === "string") {
+				ids.add(sessionId);
+			}
+		}
+	}
+	return Array.from(ids);
+}

--- a/cli/src/utils/resource-manager.ts
+++ b/cli/src/utils/resource-manager.ts
@@ -334,7 +334,9 @@ export class ResourceManager {
 		const stats = this.getStats();
 		if (stats.totalDiskUsage > this.maxMemoryUsage) {
 			// Clean up oldest resources first
-			this.cleanup({ maxAge: 10 * 60 * 1000 }); // 10 minutes
+			void this.cleanup({ maxAge: 10 * 60 * 1000 }).catch((err) => {
+				console.error("Memory-triggered cleanup failed:", err);
+			}); // 10 minutes
 		}
 	}
 

--- a/cli/src/utils/resource-manager.ts
+++ b/cli/src/utils/resource-manager.ts
@@ -1,0 +1,445 @@
+/**
+ * ResourceManager - Manages system resources including files, memory, and cleanup operations
+ * Provides centralized resource tracking, cleanup, and error handling
+ */
+
+import type { ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	rmdirSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { registerCleanup, registerProcess } from "./cleanup.ts";
+import { RalphyError, standardizeError } from "./errors.ts";
+
+/**
+ * Generate a cryptographically secure random string for resource IDs
+ */
+function generateSecureId(): string {
+	return randomBytes(8).toString("hex");
+}
+
+export class ResourceError extends RalphyError {
+	constructor(message: string, context?: Record<string, unknown>) {
+		super(message, "RESOURCE_ERROR", context);
+		this.name = "ResourceError";
+	}
+}
+
+interface ResourceInfo {
+	id: string;
+	type: "file" | "directory" | "process" | "memory" | "temp";
+	path?: string;
+	process?: ChildProcess;
+	data?: unknown;
+	created: Date;
+	lastAccessed: Date;
+	size?: number;
+	cleanup?: () => void | Promise<void>;
+}
+
+interface ResourceStats {
+	totalResources: number;
+	filesTracked: number;
+	processesTracked: number;
+	tempDirectories: number;
+	totalDiskUsage: number;
+	oldestResource: Date | null;
+}
+
+/**
+ * ResourceManager - Centralized resource management with automatic cleanup
+ */
+export class ResourceManager {
+	private resources: Map<string, ResourceInfo> = new Map();
+	private maxMemoryUsage: number;
+	private maxTempFileSize: number;
+	private cleanupInterval: number;
+	private intervalId?: NodeJS.Timeout;
+
+	constructor(
+		options: {
+			maxMemoryUsage?: number;
+			maxTempFileSize?: number;
+			cleanupInterval?: number;
+		} = {},
+	) {
+		this.maxMemoryUsage = options.maxMemoryUsage ?? 100 * 1024 * 1024; // 100MB
+		this.maxTempFileSize = options.maxTempFileSize ?? 10 * 1024 * 1024; // 10MB
+		this.cleanupInterval = options.cleanupInterval ?? 60000; // 1 minute
+
+		// Register cleanup handler
+		registerCleanup(() => this.cleanup());
+
+		// Start periodic cleanup
+		this.startPeriodicCleanup();
+	}
+
+	/**
+	 * Create a temporary directory and track it for cleanup
+	 * Uses system temp directory for security (not process.cwd())
+	 */
+	createTempDir(prefix = "ralphy-temp"): string {
+		// Use system temp directory for security, with cryptographically secure random suffix
+		const tempDir = join(tmpdir(), `${prefix}-${Date.now()}-${generateSecureId()}`);
+
+		try {
+			mkdirSync(tempDir, { recursive: true });
+
+			const resourceId = `temp-dir-${generateSecureId()}`;
+			this.resources.set(resourceId, {
+				id: resourceId,
+				type: "directory",
+				path: tempDir,
+				created: new Date(),
+				lastAccessed: new Date(),
+				cleanup: () => {
+					if (existsSync(tempDir)) {
+						this.removeDirectory(tempDir);
+					}
+				},
+			});
+
+			return tempDir;
+		} catch (error) {
+			throw new ResourceError(`Failed to create temp directory: ${tempDir}`, {
+				tempDir,
+				error: standardizeError(error),
+			});
+		}
+	}
+
+	/**
+	 * Create a temporary file and track it for cleanup
+	 * Uses system temp directory for security (not process.cwd())
+	 */
+	createTempFile(content: string | Buffer, prefix = "ralphy-temp", extension = ".tmp"): string {
+		// Use system temp directory for security, with cryptographically secure random suffix
+		const tempFile = join(tmpdir(), `${prefix}-${Date.now()}-${generateSecureId()}${extension}`);
+
+		try {
+			// Check file size limits
+			const contentSize = typeof content === "string" ? content.length : content.length;
+			if (contentSize > this.maxTempFileSize) {
+				throw new ResourceError(`Temp file size exceeds limit: ${contentSize} > ${this.maxTempFileSize}`);
+			}
+
+			writeFileSync(tempFile, content);
+
+			const resourceId = `temp-file-${generateSecureId()}`;
+			this.resources.set(resourceId, {
+				id: resourceId,
+				type: "file",
+				path: tempFile,
+				created: new Date(),
+				lastAccessed: new Date(),
+				size: contentSize,
+				cleanup: () => {
+					if (existsSync(tempFile)) {
+						unlinkSync(tempFile);
+					}
+				},
+			});
+
+			return tempFile;
+		} catch (error) {
+			throw new ResourceError(`Failed to create temp file: ${tempFile}`, {
+				tempFile,
+				error: standardizeError(error),
+			});
+		}
+	}
+
+	/**
+	 * Track a file resource for management
+	 */
+	trackFile(filePath: string, autoCleanup = false): string {
+		const resolvedPath = resolve(filePath);
+
+		try {
+			if (!existsSync(resolvedPath)) {
+				throw new ResourceError(`File does not exist: ${resolvedPath}`);
+			}
+
+			const stats = statSync(resolvedPath);
+			const resourceId = `file-${Date.now()}-${generateSecureId()}`;
+
+			this.resources.set(resourceId, {
+				id: resourceId,
+				type: "file",
+				path: resolvedPath,
+				created: new Date(),
+				lastAccessed: new Date(),
+				size: stats.size,
+				cleanup: autoCleanup
+					? () => {
+							if (existsSync(resolvedPath)) {
+								unlinkSync(resolvedPath);
+							}
+						}
+					: undefined,
+			});
+
+			return resourceId;
+		} catch (error) {
+			throw new ResourceError(`Failed to track file: ${resolvedPath}`, {
+				resolvedPath,
+				error: standardizeError(error),
+			});
+		}
+	}
+
+	/**
+	 * Track a process resource for management
+	 */
+	trackProcess(process: ChildProcess): string {
+		const resourceId = `process-${Date.now()}-${generateSecureId()}`;
+
+		// Register with global cleanup system
+		const removeCleanup = registerProcess(process);
+
+		this.resources.set(resourceId, {
+			id: resourceId,
+			type: "process",
+			process,
+			created: new Date(),
+			lastAccessed: new Date(),
+			cleanup: removeCleanup,
+		});
+
+		return resourceId;
+	}
+
+	/**
+	 * Track in-memory data resource
+	 */
+	trackMemory(data: unknown, _description = ""): string {
+		const resourceId = `memory-${Date.now()}-${generateSecureId()}`;
+
+		// Estimate memory usage (rough approximation)
+		let size = 0;
+		try {
+			size = JSON.stringify(data).length * 2; // UTF-16 bytes
+		} catch {
+			// Non-serializable values (e.g. circular refs, BigInt) are allowed; skip size estimate.
+		}
+
+		this.resources.set(resourceId, {
+			id: resourceId,
+			type: "memory",
+			data,
+			created: new Date(),
+			lastAccessed: new Date(),
+			size,
+		});
+
+		return resourceId;
+	}
+
+	/**
+	 * Get tracked resource information
+	 */
+	getResource(resourceId: string): ResourceInfo | undefined {
+		const resource = this.resources.get(resourceId);
+		if (resource) {
+			resource.lastAccessed = new Date();
+		}
+		return resource;
+	}
+
+	/**
+	 * Remove a specific resource and trigger its cleanup
+	 */
+	async removeResource(resourceId: string): Promise<void> {
+		const resource = this.resources.get(resourceId);
+		if (!resource) {
+			return;
+		}
+
+		try {
+			if (resource.cleanup) {
+				await resource.cleanup();
+			}
+			this.resources.delete(resourceId);
+		} catch (error) {
+			throw new ResourceError(`Failed to cleanup resource: ${resourceId}`, {
+				resourceId,
+				error: standardizeError(error),
+			});
+		}
+	}
+
+	/**
+	 * Get resource statistics
+	 */
+	getStats(): ResourceStats {
+		const resources = Array.from(this.resources.values());
+		const filesTracked = resources.filter((r) => r.type === "file").length;
+		const processesTracked = resources.filter((r) => r.type === "process").length;
+		const tempDirectories = resources.filter((r) => r.type === "directory").length;
+		const totalDiskUsage = resources.filter((r) => r.size).reduce((sum, r) => sum + (r.size ?? 0), 0);
+		const oldestResource =
+			resources.length > 0 ? new Date(Math.min(...resources.map((r) => r.created.getTime()))) : null;
+
+		return {
+			totalResources: resources.length,
+			filesTracked,
+			processesTracked,
+			tempDirectories,
+			totalDiskUsage,
+			oldestResource,
+		};
+	}
+
+	/**
+	 * Clean up old or expired resources
+	 */
+	async cleanup(options: { maxAge?: number; force?: boolean } = {}): Promise<void> {
+		const { maxAge = 30 * 60 * 1000, force = false } = options; // 30 minutes default
+		const now = Date.now();
+		const resourcesToRemove: string[] = [];
+
+		for (const [id, resource] of this.resources) {
+			const age = now - resource.created.getTime();
+
+			if (force || age > maxAge) {
+				resourcesToRemove.push(id);
+			}
+		}
+
+		// Remove resources in parallel
+		await Promise.allSettled(resourcesToRemove.map((id) => this.removeResource(id)));
+	}
+
+	/**
+	 * Force cleanup of all resources
+	 */
+	async cleanupAll(): Promise<void> {
+		const resourceIds = Array.from(this.resources.keys());
+		await Promise.allSettled(resourceIds.map((id) => this.removeResource(id)));
+	}
+
+	/**
+	 * Check memory usage and cleanup if necessary
+	 */
+	private checkMemoryUsage(): void {
+		const stats = this.getStats();
+		if (stats.totalDiskUsage > this.maxMemoryUsage) {
+			// Clean up oldest resources first
+			this.cleanup({ maxAge: 10 * 60 * 1000 }); // 10 minutes
+		}
+	}
+
+	/**
+	 * Start periodic cleanup
+	 */
+	private startPeriodicCleanup(): void {
+		this.intervalId = setInterval(() => {
+			this.checkMemoryUsage();
+			this.cleanup().catch((err) => {
+				console.error("Cleanup failed:", err);
+			});
+		}, this.cleanupInterval);
+	}
+
+	/**
+	 * Stop periodic cleanup
+	 */
+	stopPeriodicCleanup(): void {
+		if (this.intervalId) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+	}
+
+	/**
+	 * Recursively remove a directory
+	 */
+	private removeDirectory(dirPath: string): void {
+		try {
+			rmSync(dirPath, { recursive: true, force: true });
+		} catch (_error) {
+			// Fallback for older Node.js versions
+			try {
+				const files = readdirSync(dirPath);
+				for (const file of files) {
+					const filePath = join(dirPath, file);
+					const stats = statSync(filePath);
+					if (stats.isDirectory()) {
+						this.removeDirectory(filePath);
+					} else {
+						unlinkSync(filePath);
+					}
+				}
+				rmdirSync(dirPath);
+			} catch (_fallbackError) {
+				// Fallback cleanup failed, ignore to prevent blocking
+			}
+		}
+	}
+
+	/**
+	 * Get list of all tracked resources
+	 */
+	listResources(): ResourceInfo[] {
+		return Array.from(this.resources.values());
+	}
+
+	/**
+	 * Check if a resource exists and is accessible
+	 */
+	validateResource(resourceId: string): boolean {
+		const resource = this.resources.get(resourceId);
+		if (!resource) {
+			return false;
+		}
+
+		switch (resource.type) {
+			case "file":
+				return resource.path ? existsSync(resource.path) : false;
+			case "process":
+				return resource.process ? Boolean(resource.process.pid) : false;
+			case "directory":
+				return resource.path ? existsSync(resource.path) : false;
+			case "memory":
+			case "temp":
+				return true; // Always valid unless explicitly removed
+			default:
+				return false;
+		}
+	}
+}
+
+// Global instance for singleton usage
+let globalResourceManager: ResourceManager | undefined;
+
+/**
+ * Get or create the global ResourceManager instance
+ */
+export function getResourceManager(): ResourceManager {
+	if (!globalResourceManager) {
+		globalResourceManager = new ResourceManager();
+	}
+	return globalResourceManager;
+}
+
+/**
+ * Reset the global ResourceManager (useful for testing)
+ */
+export function resetResourceManager(): void {
+	if (globalResourceManager) {
+		globalResourceManager.stopPeriodicCleanup();
+		globalResourceManager.cleanupAll().catch((err) => {
+			console.error("Global cleanup failed:", err);
+		});
+		globalResourceManager = undefined;
+	}
+}

--- a/cli/src/utils/sanitization.ts
+++ b/cli/src/utils/sanitization.ts
@@ -32,6 +32,7 @@ export function sanitizeSecrets(input: string): string {
 	// Patterns are designed to match specific token formats with fixed lengths
 	const patterns = [
 		{ regex: /sk-[a-zA-Z0-9]{48}/g, replacement: "[API_KEY_REDACTED]" },
+		{ regex: /sk-ant-[a-zA-Z0-9_-]{16,256}/g, replacement: "[ANTHROPIC_KEY_REDACTED]" },
 		{ regex: /ghp_[a-zA-Z0-9]{36}/g, replacement: "[GITHUB_TOKEN_REDACTED]" },
 		{ regex: /gho_[a-zA-Z0-9]{52}/g, replacement: "[GITHUB_OAUTH_REDACTED]" },
 		{ regex: /AKIA[0-9A-Z]{16}/g, replacement: "[AWS_KEY_REDACTED]" },

--- a/cli/src/utils/sanitization.ts
+++ b/cli/src/utils/sanitization.ts
@@ -1,0 +1,49 @@
+/**
+ * Sanitization utilities for removing sensitive data
+ *
+ * SECURITY: All patterns use bounded quantifiers to prevent ReDoS attacks
+ */
+
+/**
+ * Maximum input length for secret sanitization to prevent ReDoS
+ */
+const MAX_SANITIZE_INPUT_LENGTH = 1000000; // 1MB
+
+/**
+ * Sanitize sensitive data (API keys, passwords, etc.) from string input
+ *
+ * SECURITY NOTE: This function includes protections against ReDoS attacks:
+ * - Input length is limited to MAX_SANITIZE_INPUT_LENGTH
+ * - All regex patterns use bounded quantifiers (e.g., {48}, {36})
+ * - Patterns are applied sequentially with early exit if input becomes too large
+ *
+ * @param input - The string to sanitize
+ * @returns Sanitized string with secrets redacted
+ */
+export function sanitizeSecrets(input: string): string {
+	// Limit input length to prevent ReDoS attacks
+	if (input.length > MAX_SANITIZE_INPUT_LENGTH) {
+		// For very large inputs, truncate and add warning
+		const truncated = input.slice(0, MAX_SANITIZE_INPUT_LENGTH);
+		return `${truncated}\n\n[WARNING: Content truncated due to size limits during secret sanitization]`;
+	}
+
+	// All patterns use bounded quantifiers to prevent ReDoS
+	// Patterns are designed to match specific token formats with fixed lengths
+	const patterns = [
+		{ regex: /sk-[a-zA-Z0-9]{48}/g, replacement: "[API_KEY_REDACTED]" },
+		{ regex: /ghp_[a-zA-Z0-9]{36}/g, replacement: "[GITHUB_TOKEN_REDACTED]" },
+		{ regex: /gho_[a-zA-Z0-9]{52}/g, replacement: "[GITHUB_OAUTH_REDACTED]" },
+		{ regex: /AKIA[0-9A-Z]{16}/g, replacement: "[AWS_KEY_REDACTED]" },
+		// For hex secrets, use a bounded length and require word boundaries to prevent
+		// matching large hex strings that could cause performance issues
+		{ regex: /\b[0-9a-f]{64}\b/g, replacement: "[HEX_SECRET_REDACTED]" },
+	];
+
+	let result = input;
+	for (const { regex, replacement } of patterns) {
+		result = result.replace(regex, replacement);
+	}
+
+	return result;
+}

--- a/cli/src/utils/templates.ts
+++ b/cli/src/utils/templates.ts
@@ -1,0 +1,469 @@
+/**
+ * Prompt Template System for Ralphy CLI
+ *
+ * Provides customizable prompt building with:
+ * - Template variables
+ * - Conditional sections
+ * - Template inheritance
+ * - Multiple output formats
+ */
+
+import { logDebugContext, logErrorContext } from "../ui/logger.ts";
+
+/**
+ * Template variable definition
+ */
+export interface TemplateVariable {
+	/** Variable name */
+	name: string;
+	/** Variable description */
+	description: string;
+	/** Default value */
+	default?: string;
+	/** Whether variable is required */
+	required?: boolean;
+	/** Validation regex pattern */
+	pattern?: string;
+}
+
+/**
+ * Template section
+ */
+export interface TemplateSection {
+	/** Section name */
+	name: string;
+	/** Section content (can include variables) */
+	content: string;
+	/** Condition to include this section */
+	condition?: string;
+	/** Section priority (for ordering) */
+	priority?: number;
+}
+
+/**
+ * Prompt template definition
+ */
+export interface PromptTemplate {
+	/** Template name */
+	name: string;
+	/** Template description */
+	description: string;
+	/** Template version */
+	version: string;
+	/** Variables used in template */
+	variables: TemplateVariable[];
+	/** Template sections */
+	sections: TemplateSection[];
+	/** Base template to extend (optional) */
+	extends?: string;
+	/** Output format */
+	outputFormat?: "text" | "markdown" | "json";
+}
+
+/**
+ * Template context with variable values
+ */
+export interface TemplateContext {
+	[variableName: string]: string | number | boolean | string[];
+}
+
+/**
+ * Rendered prompt result
+ */
+export interface RenderedPrompt {
+	/** Rendered prompt text */
+	prompt: string;
+	/** Variables that were used */
+	usedVariables: string[];
+	/** Sections that were included */
+	includedSections: string[];
+	/** Template metadata */
+	metadata: {
+		templateName: string;
+		version: string;
+		renderedAt: string;
+	};
+}
+
+/**
+ * Template engine for building prompts
+ */
+export class TemplateEngine {
+	private templates: Map<string, PromptTemplate> = new Map();
+	private parentEngine?: TemplateEngine;
+
+	constructor(parent?: TemplateEngine) {
+		this.parentEngine = parent;
+	}
+
+	/**
+	 * Register a template
+	 */
+	register(template: PromptTemplate): void {
+		// Validate template
+		this.validateTemplate(template);
+
+		this.templates.set(template.name, template);
+		logDebugContext("TemplateEngine", `Registered template: ${template.name} v${template.version}`);
+	}
+
+	/**
+	 * Get a template by name
+	 */
+	getTemplate(name: string): PromptTemplate | undefined {
+		return this.templates.get(name) || this.parentEngine?.getTemplate(name);
+	}
+
+	/**
+	 * Check if template exists
+	 */
+	hasTemplate(name: string): boolean {
+		return this.templates.has(name) || (this.parentEngine?.hasTemplate(name) ?? false);
+	}
+
+	/**
+	 * Render a template with context
+	 */
+	render(templateName: string, context: TemplateContext): RenderedPrompt {
+		const template = this.getTemplate(templateName);
+		if (!template) {
+			throw new Error(`Template not found: ${templateName}`);
+		}
+
+		// If template extends another, merge with parent
+		let effectiveTemplate = template;
+		if (template.extends) {
+			const parentTemplate = this.getTemplate(template.extends);
+			if (parentTemplate) {
+				effectiveTemplate = this.mergeTemplates(parentTemplate, template);
+			}
+		}
+
+		// Validate context
+		this.validateContext(effectiveTemplate, context);
+
+		// Render sections
+		const includedSections: string[] = [];
+		const renderedSections: string[] = [];
+
+		// Sort sections by priority
+		const sortedSections = [...effectiveTemplate.sections].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+
+		for (const section of sortedSections) {
+			// Check condition
+			if (section.condition && !this.evaluateCondition(section.condition, context)) {
+				continue;
+			}
+
+			includedSections.push(section.name);
+
+			// Render variables in section content
+			let renderedContent = this.renderVariables(section.content, context);
+
+			// Apply output format
+			renderedContent = this.applyOutputFormat(renderedContent, effectiveTemplate.outputFormat);
+
+			renderedSections.push(renderedContent);
+		}
+
+		const usedVariables = effectiveTemplate.variables.map((v) => v.name);
+
+		return {
+			prompt: renderedSections.join("\n\n"),
+			usedVariables,
+			includedSections,
+			metadata: {
+				templateName: template.name,
+				version: template.version,
+				renderedAt: new Date().toISOString(),
+			},
+		};
+	}
+
+	/**
+	 * Render a template string directly with context
+	 */
+	renderString(templateString: string, context: TemplateContext): string {
+		return this.renderVariables(templateString, context);
+	}
+
+	/**
+	 * Get all registered template names
+	 */
+	getTemplateNames(): string[] {
+		const names = Array.from(this.templates.keys());
+		if (this.parentEngine) {
+			const parentNames = this.parentEngine.getTemplateNames();
+			return [...new Set([...names, ...parentNames])];
+		}
+		return names;
+	}
+
+	/**
+	 * Unregister a template
+	 */
+	unregister(name: string): boolean {
+		const deleted = this.templates.delete(name);
+		if (deleted) {
+			logDebugContext("TemplateEngine", `Unregistered template: ${name}`);
+		}
+		return deleted;
+	}
+
+	/**
+	 * Clear all templates
+	 */
+	clear(): void {
+		this.templates.clear();
+		logDebugContext("TemplateEngine", "All templates cleared");
+	}
+
+	// Private helpers
+
+	private validateTemplate(template: PromptTemplate): void {
+		if (!template.name) {
+			throw new Error("Template must have a name");
+		}
+		if (!template.sections || template.sections.length === 0) {
+			throw new Error(`Template ${template.name} must have at least one section`);
+		}
+
+		// Check for duplicate variable names
+		const varNames = new Set<string>();
+		for (const variable of template.variables) {
+			if (varNames.has(variable.name)) {
+				throw new Error(`Duplicate variable name in template ${template.name}: ${variable.name}`);
+			}
+			varNames.add(variable.name);
+		}
+
+		// Validate variable references in sections
+		for (const section of template.sections) {
+			const varRefs = this.extractVariableReferences(section.content);
+			for (const ref of varRefs) {
+				if (!varNames.has(ref)) {
+					logErrorContext("TemplateEngine", `Template ${template.name} references undefined variable: ${ref}`);
+				}
+			}
+		}
+	}
+
+	private validateContext(template: PromptTemplate, context: TemplateContext): void {
+		for (const variable of template.variables) {
+			if (variable.required && !(variable.name in context)) {
+				throw new Error(`Missing required variable '${variable.name}' for template '${template.name}'`);
+			}
+
+			if (variable.pattern && context[variable.name]) {
+				const value = String(context[variable.name]);
+				const regex = new RegExp(variable.pattern);
+				if (!regex.test(value)) {
+					throw new Error(`Variable '${variable.name}' value '${value}' does not match pattern '${variable.pattern}'`);
+				}
+			}
+		}
+	}
+
+	private mergeTemplates(parent: PromptTemplate, child: PromptTemplate): PromptTemplate {
+		// Merge sections (child overrides parent with same name)
+		const parentSections = new Map(parent.sections.map((s) => [s.name, s]));
+		const mergedSections: TemplateSection[] = [];
+
+		for (const section of child.sections) {
+			parentSections.set(section.name, section);
+		}
+
+		for (const section of parentSections.values()) {
+			mergedSections.push(section);
+		}
+
+		// Merge variables (child overrides parent with same name)
+		const parentVars = new Map(parent.variables.map((v) => [v.name, v]));
+		for (const variable of child.variables) {
+			parentVars.set(variable.name, variable);
+		}
+
+		return {
+			name: child.name,
+			description: child.description || parent.description,
+			version: child.version,
+			variables: Array.from(parentVars.values()),
+			sections: mergedSections,
+			outputFormat: child.outputFormat || parent.outputFormat,
+		};
+	}
+
+	private extractVariableReferences(content: string): string[] {
+		const regex = /\{\{(\w+)\}\}/g;
+		const matches: string[] = [];
+		let match: RegExpExecArray | null = null;
+
+		while (true) {
+			match = regex.exec(content);
+			if (match === null) break;
+			matches.push(match[1]);
+		}
+
+		return matches;
+	}
+
+	private renderVariables(content: string, context: TemplateContext): string {
+		return content.replace(/\{\{(\w+)\}\}/g, (match, varName) => {
+			if (varName in context) {
+				const value = context[varName];
+				if (Array.isArray(value)) {
+					return value.join("\n");
+				}
+				return String(value);
+			}
+			return match; // Keep original if not found
+		});
+	}
+
+	private evaluateCondition(condition: string, context: TemplateContext): boolean {
+		// Simple condition evaluation
+		// Supports: variable, !variable, variable=value, variable!=value
+		const normalizedCondition = condition.trim();
+
+		// Negation
+		if (normalizedCondition.startsWith("!")) {
+			const varName = normalizedCondition.slice(1);
+			return !context[varName];
+		}
+
+		// Equality check
+		const eqMatch = normalizedCondition.match(/^(\w+)=(.+)$/);
+		if (eqMatch) {
+			const [, varName, expectedValue] = eqMatch;
+			return String(context[varName]) === expectedValue;
+		}
+
+		// Inequality check
+		const neqMatch = normalizedCondition.match(/^(\w+)!=(.+)$/);
+		if (neqMatch) {
+			const [, varName, expectedValue] = neqMatch;
+			return String(context[varName]) !== expectedValue;
+		}
+
+		// Simple truthy check
+		return !!context[normalizedCondition];
+	}
+
+	private applyOutputFormat(content: string, format?: string): string {
+		switch (format) {
+			case "markdown":
+				// Ensure proper markdown formatting
+				return content.trim();
+			case "json":
+				// Escape for JSON
+				return JSON.stringify(content).slice(1, -1);
+			default:
+				return content;
+		}
+	}
+}
+
+/**
+ * Global template engine instance
+ */
+let globalTemplateEngine: TemplateEngine = new TemplateEngine();
+
+/**
+ * Set global template engine
+ */
+export function setTemplateEngine(engine: TemplateEngine): void {
+	globalTemplateEngine = engine;
+}
+
+/**
+ * Get global template engine
+ */
+export function getTemplateEngine(): TemplateEngine {
+	return globalTemplateEngine;
+}
+
+/**
+ * Register a template (convenience function)
+ */
+export function registerTemplate(template: PromptTemplate): void {
+	globalTemplateEngine.register(template);
+}
+
+/**
+ * Render a template (convenience function)
+ */
+export function renderTemplate(templateName: string, context: TemplateContext): RenderedPrompt {
+	return globalTemplateEngine.render(templateName, context);
+}
+
+/**
+ * Built-in templates for common use cases
+ */
+export const builtInTemplates: PromptTemplate[] = [
+	{
+		name: "default-task",
+		description: "Default template for task execution",
+		version: "1.0.0",
+		variables: [
+			{ name: "task", description: "Task description", required: true },
+			{ name: "project", description: "Project name", default: "unknown" },
+			{ name: "language", description: "Programming language", default: "TypeScript" },
+			{ name: "rules", description: "Additional rules", default: "" },
+		],
+		sections: [
+			{
+				name: "header",
+				content: "# Task: {{task}}\n\nProject: {{project}}\nLanguage: {{language}}",
+				priority: 0,
+			},
+			{
+				name: "rules",
+				content: "\n## Rules\n\n{{rules}}",
+				condition: "rules",
+				priority: 10,
+			},
+			{
+				name: "instructions",
+				content: "\n## Instructions\n\nPlease complete the above task following all specified rules.",
+				priority: 100,
+			},
+		],
+		outputFormat: "markdown",
+	},
+	{
+		name: "code-review",
+		description: "Template for code review tasks",
+		version: "1.0.0",
+		variables: [
+			{ name: "file", description: "File to review", required: true },
+			{ name: "content", description: "File content", required: true },
+			{ name: "focus", description: "Review focus areas", default: "bugs,security,performance" },
+		],
+		sections: [
+			{
+				name: "header",
+				content: "# Code Review: {{file}}\n\nFocus areas: {{focus}}",
+				priority: 0,
+			},
+			{
+				name: "code",
+				content: "\n## Code\n\n```\n{{content}}\n```",
+				priority: 10,
+			},
+			{
+				name: "instructions",
+				content:
+					"\n## Instructions\n\nReview the code above focusing on the specified areas. Provide specific, actionable feedback.",
+				priority: 100,
+			},
+		],
+		outputFormat: "markdown",
+	},
+];
+
+// Register built-in templates on module load
+for (const template of builtInTemplates) {
+	globalTemplateEngine.register(template);
+}
+
+// TemplateEngine is already exported above

--- a/cli/src/utils/transform.ts
+++ b/cli/src/utils/transform.ts
@@ -1,0 +1,369 @@
+/**
+ * Data Transformation Layer for Ralphy CLI
+ *
+ * Separates prompt building from execution logic with:
+ * - Transform pipelines
+ * - Data sanitization
+ * - Context enrichment
+ * - Format conversion
+ */
+
+import type { Task } from "../tasks/types.ts";
+import { logDebugContext, logErrorContext } from "../ui/logger.ts";
+
+/**
+ * Context data for transformation
+ */
+export interface TransformContext {
+	task: Task;
+	workDir: string;
+	engine: string;
+	config?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Transformation result
+ */
+export interface TransformResult {
+	/** Transformed data */
+	data: string;
+	/** Metadata about the transformation */
+	metadata: {
+		transformer: string;
+		inputLength: number;
+		outputLength: number;
+		processingTimeMs: number;
+	};
+}
+
+/**
+ * Transformer function type
+ */
+export type Transformer = (input: string, context: TransformContext) => string;
+
+/**
+ * Transformer registration
+ */
+interface RegisteredTransformer {
+	name: string;
+	transformer: Transformer;
+	priority: number;
+}
+
+/**
+ * Data transformation pipeline
+ */
+export class TransformPipeline {
+	private transformers: RegisteredTransformer[] = [];
+	private enabled = true;
+
+	/**
+	 * Register a transformer
+	 */
+	register(name: string, transformer: Transformer, options?: { priority?: number }): () => void {
+		const entry: RegisteredTransformer = {
+			name,
+			transformer,
+			priority: options?.priority ?? 0,
+		};
+
+		this.transformers.push(entry);
+
+		// Sort by priority (lower first)
+		this.transformers.sort((a, b) => a.priority - b.priority);
+
+		logDebugContext("TransformPipeline", `Registered transformer: ${name} (priority: ${entry.priority})`);
+
+		// Return unregister function
+		return () => {
+			const index = this.transformers.findIndex((t) => t.name === name);
+			if (index !== -1) {
+				this.transformers.splice(index, 1);
+				logDebugContext("TransformPipeline", `Unregistered transformer: ${name}`);
+			}
+		};
+	}
+
+	/**
+	 * Execute the transformation pipeline
+	 */
+	async execute(input: string, context: TransformContext): Promise<TransformResult> {
+		// Lazy-register built-in transformers to avoid circular dependency
+		registerBuiltInTransformers();
+
+		if (!this.enabled || this.transformers.length === 0) {
+			return {
+				data: input,
+				metadata: {
+					transformer: "passthrough",
+					inputLength: input.length,
+					outputLength: input.length,
+					processingTimeMs: 0,
+				},
+			};
+		}
+
+		const startTime = Date.now();
+		let result = input;
+		const appliedTransformers: string[] = [];
+
+		for (const entry of this.transformers) {
+			try {
+				result = await entry.transformer(result, context);
+				appliedTransformers.push(entry.name);
+			} catch (error) {
+				logErrorContext("TransformPipeline", `Transformer ${entry.name} failed: ${error}`);
+				// Continue with other transformers
+			}
+		}
+
+		const processingTimeMs = Date.now() - startTime;
+
+		logDebugContext("TransformPipeline", `Applied ${appliedTransformers.length} transformers in ${processingTimeMs}ms`);
+
+		return {
+			data: result,
+			metadata: {
+				transformer: appliedTransformers.join(","),
+				inputLength: input.length,
+				outputLength: result.length,
+				processingTimeMs,
+			},
+		};
+	}
+
+	/**
+	 * Enable/disable the pipeline
+	 */
+	setEnabled(enabled: boolean): void {
+		this.enabled = enabled;
+		logDebugContext("TransformPipeline", `Pipeline ${enabled ? "enabled" : "disabled"}`);
+	}
+
+	/**
+	 * Clear all transformers
+	 */
+	clear(): void {
+		this.transformers = [];
+		logDebugContext("TransformPipeline", "All transformers cleared");
+	}
+
+	/**
+	 * Get registered transformer names
+	 */
+	getTransformerNames(): string[] {
+		return this.transformers.map((t) => t.name);
+	}
+}
+
+/**
+ * Global transform pipeline instance
+ */
+let globalTransformPipeline: TransformPipeline = new TransformPipeline();
+
+/**
+ * Set global transform pipeline
+ */
+export function setTransformPipeline(pipeline: TransformPipeline): void {
+	globalTransformPipeline = pipeline;
+}
+
+/**
+ * Get global transform pipeline
+ */
+export function getTransformPipeline(): TransformPipeline {
+	return globalTransformPipeline;
+}
+
+/**
+ * Register a transformer (convenience function)
+ */
+export function registerTransformer(
+	name: string,
+	transformer: Transformer,
+	options?: { priority?: number },
+): () => void {
+	return globalTransformPipeline.register(name, transformer, options);
+}
+
+/**
+ * Execute transformation pipeline (convenience function)
+ */
+export async function transform(input: string, context: TransformContext): Promise<TransformResult> {
+	return globalTransformPipeline.execute(input, context);
+}
+
+// ============== Built-in Transformers ==============
+
+/**
+ * Maximum input length for secret sanitization to prevent ReDoS
+ */
+const MAX_SANITIZE_INPUT_LENGTH = 1000000; // 1MB
+
+/**
+ * Sanitize sensitive data (API keys, passwords, etc.)
+ *
+ * SECURITY NOTE: This function includes protections against ReDoS attacks:
+ * - Input length is limited to MAX_SANITIZE_INPUT_LENGTH
+ * - All regex patterns use bounded quantifiers (e.g., {48}, {36})
+ * - Patterns are applied sequentially with early exit if input becomes too large
+ */
+export const sanitizeSecretsTransformer: Transformer = (input) => {
+	// Limit input length to prevent ReDoS attacks
+	if (input.length > MAX_SANITIZE_INPUT_LENGTH) {
+		// For very large inputs, truncate and add warning
+		const truncated = input.slice(0, MAX_SANITIZE_INPUT_LENGTH);
+		return `${truncated}\n\n[WARNING: Content truncated due to size limits during secret sanitization]`;
+	}
+
+	// All patterns use bounded quantifiers to prevent ReDoS
+	// Patterns are designed to match specific token formats with fixed lengths
+	const patterns = [
+		{ regex: /sk-[a-zA-Z0-9]{48}/g, replacement: "[API_KEY_REDACTED]" },
+		{ regex: /ghp_[a-zA-Z0-9]{36}/g, replacement: "[GITHUB_TOKEN_REDACTED]" },
+		{ regex: /gho_[a-zA-Z0-9]{52}/g, replacement: "[GITHUB_OAUTH_REDACTED]" },
+		{ regex: /AKIA[0-9A-Z]{16}/g, replacement: "[AWS_KEY_REDACTED]" },
+		// For hex secrets, use a bounded length and require word boundaries to prevent
+		// matching large hex strings that could cause performance issues
+		{ regex: /\b[0-9a-f]{64}\b/g, replacement: "[HEX_SECRET_REDACTED]" },
+	];
+
+	let result = input;
+	for (const { regex, replacement } of patterns) {
+		result = result.replace(regex, replacement);
+	}
+
+	return result;
+};
+
+/**
+ * Truncate long content to fit within token limits
+ */
+export const truncateContentTransformer: Transformer = (input, context) => {
+	const maxLength = (context.config?.maxPromptLength as number) || 50000;
+
+	if (input.length <= maxLength) {
+		return input;
+	}
+
+	// Smart truncation: try to break at a reasonable point
+	const truncationPoint = input.lastIndexOf("\n\n", maxLength);
+	const breakPoint = truncationPoint > maxLength * 0.8 ? truncationPoint : maxLength;
+
+	return `${input.substring(0, breakPoint)}\n\n[Content truncated: ${input.length - breakPoint} characters omitted]`;
+};
+
+/**
+ * Add metadata header to prompts
+ */
+export const addMetadataHeaderTransformer: Transformer = (input, context) => {
+	const timestamp = new Date().toISOString();
+	const header = `<!--
+Task: ${context.task.title}
+Engine: ${context.engine}
+Timestamp: ${timestamp}
+-->
+
+`;
+	return header + input;
+};
+
+/**
+ * Normalize line endings
+ */
+export const normalizeLineEndingsTransformer: Transformer = (input) => {
+	return input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+};
+
+/**
+ * Remove excessive blank lines
+ */
+export const removeExcessiveWhitespaceTransformer: Transformer = (input) => {
+	return input.replace(/\n{4,}/g, "\n\n\n");
+};
+
+/**
+ * Format code blocks consistently
+ */
+export const formatCodeBlocksTransformer: Transformer = (input) => {
+	// Ensure code blocks have language specifiers where detectable
+	return input.replace(/```\n([\s\S]*?)```/g, (match, code) => {
+		// Try to detect language from content
+		let language = "";
+		if (code.includes("import ") || code.includes("export ")) language = "typescript";
+		else if (code.includes("function ") || code.includes("const ") || code.includes("let ")) language = "typescript";
+		else if (code.includes("def ") || code.includes("import ")) language = "python";
+		else if (code.includes("package ") || code.includes("import java.")) language = "java";
+
+		if (language) {
+			return `\`\`\`${language}\n${code}\`\`\``;
+		}
+		return match;
+	});
+};
+
+/**
+ * Strip HTML tags (for plain text output)
+ */
+export const stripHtmlTagsTransformer: Transformer = (input) => {
+	return input.replace(/<[^>]*>/g, "");
+};
+
+/**
+ * Enforce token limit estimate (rough approximation)
+ */
+export const enforceTokenLimitTransformer: Transformer = (input, context) => {
+	const maxTokens = (context.config?.maxTokens as number) || 8000;
+	// Rough estimate: 1 token ≈ 4 characters for English text
+	const estimatedTokens = input.length / 4;
+
+	if (estimatedTokens <= maxTokens) {
+		return input;
+	}
+
+	const maxChars = maxTokens * 4;
+	const truncationPoint = input.lastIndexOf("\n\n", maxChars * 0.9);
+	const breakPoint = truncationPoint > maxChars * 0.7 ? truncationPoint : Math.floor(maxChars * 0.9);
+
+	return `${input.substring(0, breakPoint)}\n\n[Token limit reached: ~${Math.floor(estimatedTokens)} tokens estimated, ${input.length - breakPoint} characters omitted]`;
+};
+
+/**
+ * Add context from task configuration
+ */
+export const addTaskContextTransformer: Transformer = (input, context) => {
+	// Get rules from task or config - safely access nested properties
+	const taskWithContext = context.task as unknown as { context?: { rules?: string[] } };
+	const rules = taskWithContext.context?.rules || [];
+	if (rules.length === 0) {
+		return input;
+	}
+
+	const rulesSection = `\n\n## Task Rules\n\n${rules.map((r: string) => `- ${r}`).join("\n")}`;
+	return input + rulesSection;
+};
+
+// Register built-in transformers on module load
+const BUILT_IN_TRANSFORMERS = [
+	{ name: "sanitize-secrets", transformer: sanitizeSecretsTransformer, priority: -100 },
+	{ name: "normalize-line-endings", transformer: normalizeLineEndingsTransformer, priority: -50 },
+	{ name: "remove-excessive-whitespace", transformer: removeExcessiveWhitespaceTransformer, priority: -40 },
+	{ name: "format-code-blocks", transformer: formatCodeBlocksTransformer, priority: -30 },
+	{ name: "add-metadata-header", transformer: addMetadataHeaderTransformer, priority: 0 },
+	{ name: "add-task-context", transformer: addTaskContextTransformer, priority: 10 },
+	{ name: "truncate-content", transformer: truncateContentTransformer, priority: 90 },
+	{ name: "enforce-token-limit", transformer: enforceTokenLimitTransformer, priority: 100 },
+];
+
+// Register built-in transformers lazily to avoid circular dependency issues
+let transformersRegistered = false;
+function registerBuiltInTransformers(): void {
+	if (transformersRegistered) return;
+	transformersRegistered = true;
+	for (const { name, transformer, priority } of BUILT_IN_TRANSFORMERS) {
+		globalTransformPipeline.register(name, transformer, { priority });
+	}
+}
+
+// TransformPipeline is already exported above


### PR DESCRIPTION

# PR5: task sources and convert

## Summary
This PR expands task ingestion/conversion and wires it into CLI entrypoints. It introduces CSV conversion flow and hardens task source parsing and validation.

## Why this PR exists
- Teams need to convert task specs between YAML/Markdown/JSON/CSV.
- Task source handlers needed stricter parsing and input validation.
- CLI needed clean conversion mode routing.

## What it adds
- CLI conversion flow:
  - `cli/src/cli/commands/convert.ts`
  - `cli/src/cli/args.ts` (`--convert-from`, `--convert-to`)
  - `cli/src/cli/commands/index.ts`
  - `cli/src/index.ts` routing updates
- Task source/converter layer updates:
  - `cli/src/tasks/csv.ts`
  - `cli/src/tasks/converter.ts`
  - `cli/src/tasks/index.ts`
  - `cli/src/tasks/markdown.ts`
  - `cli/src/tasks/markdown-folder.ts`
  - `cli/src/tasks/yaml.ts`
  - `cli/src/tasks/github.ts`

## PR preview 
- New conversion mode from CLI:
  - `ralphy --convert-from tasks.yaml --convert-to tasks.csv`
  - `ralphy --convert-from PRD.md` (auto-defaults output to `.csv`)
- Task source dispatcher now includes CSV as a first-class source type.
- Markdown-folder task IDs are validated more strictly (file + line constraints).
- YAML and GitHub task handlers reject malformed input earlier.

## Concrete scenarios this fixes
- Invalid markdown-folder task ID like `../x.md:abc`: now rejected immediately.
- YAML with malicious prototype keys: blocked during parse stage.
- GitHub repo arg with extra path segments: rejected unless strict `owner/repo`.

## Security/reliability hardening
- Markdown-folder task ID parsing now validates file + line-number constraints.
- YAML parsing upgraded with bounded prototype-pollution traversal checks.
- GitHub source repo parsing now enforces strict `owner/repo` format.
- CSV source integration aligned with task-source type contracts in the stack.

## Validation
- Included in cumulative stack verification.
- Stack passes `bun run check`, `bun tsc --noEmit`, and `bun test` in order.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add task source expansion and conversion wiring by introducing a CSV task source and a `cli.commands.runConvert` CLI path that converts YAML/Markdown/JSON PRDs to CSV
> Add a CSV-backed task source, a `--convert-from/--convert-to` CLI path that runs `cli.commands.runConvert`, and expand parallel execution to accept CSV PRDs. Harden task sources (GitHub, YAML, Markdown, markdown-folder) and sanitize/logging, add a transform pipeline, hooks, metrics, resource manager, and JSON/stream parsers. Install global cleanup and signal handling. Centralize structured logging with pluggable sinks.
>
> #### 📍Where to Start
> Start with `main` in [cli/src/index.ts](https://github.com/michaelshimeles/ralphy/pull/164/files#diff-4e5d53b79780ec257e845296172b0e131f58a02e2203429882c5141c8af678ec), then review `cli.commands.runConvert` in [cli/src/cli/commands/convert.ts](https://github.com/michaelshimeles/ralphy/pull/164/files#diff-a5b60d1aeb6c490e26c55be4e7c50b0cac1ec600fbe7f43483f82318795abeeb) and CSV source wiring in [cli/src/tasks/index.ts](https://github.com/michaelshimeles/ralphy/pull/164/files#diff-9d02e5aebd8dcb59a63d22dbca8946dc9c679143036817442d64e351ccd67ce4) and [cli/src/tasks/csv.ts](https://github.com/michaelshimeles/ralphy/pull/164/files#diff-671dcf9b9d22ef874e6ed2b2b6b2764f9b05d56b15e561efcc127b07e0858343).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 813f447.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->