### PR TITLE
feat: add --github-order flag to control issue execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,10 @@ Titles must be unique.
 ```bash
 ralphy --github owner/repo
 ralphy --github owner/repo --github-label "ready"
+ralphy --github owner/repo --github-label "task" --github-order 2,3,4,5,6
 ```
+
+Use `--github-order` to execute issues in a specific order. Without it, issues are processed in the order returned by the GitHub API (newest first). The flag takes comma-separated issue numbers — only those issues will be executed, in the exact order specified.
 
 ## Parallel Execution
 
@@ -300,6 +303,7 @@ ralphy --parallel --sandbox
 | `--json FILE` | JSON task file |
 | `--github REPO` | use GitHub issues |
 | `--github-label TAG` | filter issues by label |
+| `--github-order 2,3,4` | execute issues in this order |
 | `--sync-issue N` | sync PRD progress to GitHub issue #N |
 | `--model NAME` | override model for any engine |
 | `--sonnet` | shortcut for `--claude --model sonnet` |

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -154,7 +154,10 @@ export function parseArgs(args: string[]): {
 		githubRepo: opts.github || "",
 		githubLabel: opts.githubLabel || "",
 		githubOrder: opts.githubOrder
-			? opts.githubOrder.split(",").map((n: string) => Number.parseInt(n.trim(), 10))
+			? opts.githubOrder
+					.split(",")
+					.map((n: string) => Number.parseInt(n.trim(), 10))
+					.filter((n: number) => !Number.isNaN(n))
 			: undefined,
 		syncIssue: opts.syncIssue ? Number.parseInt(opts.syncIssue, 10) || undefined : undefined,
 		autoCommit: opts.commit !== false,

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -154,10 +154,13 @@ export function parseArgs(args: string[]): {
 		githubRepo: opts.github || "",
 		githubLabel: opts.githubLabel || "",
 		githubOrder: opts.githubOrder
-			? opts.githubOrder
-					.split(",")
-					.map((n: string) => Number.parseInt(n.trim(), 10))
-					.filter((n: number) => !Number.isNaN(n))
+			? (() => {
+					const nums = opts.githubOrder
+						.split(",")
+						.map((n: string) => Number.parseInt(n.trim(), 10))
+						.filter((n: number) => !Number.isNaN(n));
+					return nums.length > 0 ? nums : undefined;
+				})()
 			: undefined,
 		syncIssue: opts.syncIssue ? Number.parseInt(opts.syncIssue, 10) || undefined : undefined,
 		autoCommit: opts.commit !== false,

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -49,6 +49,7 @@ export function createProgram(): Command {
 		.option("--json <file>", "JSON task file")
 		.option("--github <repo>", "GitHub repo for issues (owner/repo)")
 		.option("--github-label <label>", "Filter GitHub issues by label")
+		.option("--github-order <issues>", "Execute GitHub issues in this order (comma-separated issue numbers, e.g. 2,3,4,5,6)")
 		.option("--sync-issue <number>", "Sync PRD file to GitHub issue body on each iteration")
 		.option("--no-commit", "Don't auto-commit changes")
 		.option("--browser", "Enable browser automation (agent-browser)")
@@ -152,6 +153,9 @@ export function parseArgs(args: string[]): {
 		prdIsFolder,
 		githubRepo: opts.github || "",
 		githubLabel: opts.githubLabel || "",
+		githubOrder: opts.githubOrder
+			? opts.githubOrder.split(",").map((n: string) => Number.parseInt(n.trim(), 10))
+			: undefined,
 		syncIssue: opts.syncIssue ? Number.parseInt(opts.syncIssue, 10) || undefined : undefined,
 		autoCommit: opts.commit !== false,
 		browserEnabled: opts.browser === true ? "true" : opts.browser === false ? "false" : "auto",

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -71,6 +71,7 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 		filePath: options.prdFile,
 		repo: options.githubRepo,
 		label: options.githubLabel,
+		order: options.githubOrder,
 	});
 	const taskSource = new CachedTaskSource(innerTaskSource);
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -101,6 +101,8 @@ export interface RuntimeOptions {
 	githubRepo: string;
 	/** GitHub issue label filter */
 	githubLabel: string;
+	/** Ordered list of GitHub issue numbers to execute in sequence */
+	githubOrder?: number[];
 	/** GitHub issue number to sync PRD with on each iteration */
 	syncIssue?: number;
 	/** Auto-commit changes */

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -87,16 +87,23 @@ export class GitHubTaskSource implements TaskSource {
 		// Sort by specified order if provided
 		if (this.order && this.order.length > 0) {
 			const orderMap = new Map(this.order.map((num, idx) => [num, idx]));
-			tasks = tasks
-				.filter((t) => {
-					const issueNum = Number.parseInt(t.id.split(":")[0], 10);
-					return orderMap.has(issueNum);
-				})
-				.sort((a, b) => {
-					const aNum = Number.parseInt(a.id.split(":")[0], 10);
-					const bNum = Number.parseInt(b.id.split(":")[0], 10);
-					return (orderMap.get(aNum) ?? 0) - (orderMap.get(bNum) ?? 0);
-				});
+			const tagged = tasks.map((t) => ({
+				task: t,
+				issueNum: Number.parseInt(t.id.split(":")[0], 10),
+			}));
+			const filtered = tagged.filter(({ issueNum }) => orderMap.has(issueNum));
+
+			const foundNums = new Set(filtered.map(({ issueNum }) => issueNum));
+			const missing = this.order.filter((n) => !foundNums.has(n));
+			if (missing.length > 0) {
+				console.warn(
+					`[ralphy] Warning: --github-order specified issues not found among open issues: ${missing.join(", ")}`,
+				);
+			}
+
+			tasks = filtered
+				.sort((a, b) => orderMap.get(a.issueNum)! - orderMap.get(b.issueNum)!)
+				.map(({ task }) => task);
 		}
 
 		// Update cache (preserve closed count if we have it)

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -156,7 +156,12 @@ export class GitHubTaskSource implements TaskSource {
 			per_page: 100,
 		});
 
-		const closedCount = issues.length;
+		// When order is specified, only count closed issues that are in the order list
+		let closedCount = issues.length;
+		if (this.order && this.order.length > 0) {
+			const orderSet = new Set(this.order);
+			closedCount = issues.filter((issue) => orderSet.has(issue.number)).length;
+		}
 
 		// Update cache with closed count
 		if (this.cache) {

--- a/cli/src/tasks/github.ts
+++ b/cli/src/tasks/github.ts
@@ -25,9 +25,10 @@ export class GitHubTaskSource implements TaskSource {
 	private owner: string;
 	private repo: string;
 	private label?: string;
+	private order?: number[];
 	private cache: GitHubCache | null = null;
 
-	constructor(repoPath: string, label?: string) {
+	constructor(repoPath: string, label?: string, order?: number[]) {
 		// Parse owner/repo format
 		const [owner, repo] = repoPath.split("/");
 		if (!owner || !repo) {
@@ -37,6 +38,7 @@ export class GitHubTaskSource implements TaskSource {
 		this.owner = owner;
 		this.repo = repo;
 		this.label = label;
+		this.order = order;
 
 		// Use GITHUB_TOKEN from environment
 		this.octokit = new Octokit({
@@ -75,12 +77,27 @@ export class GitHubTaskSource implements TaskSource {
 			per_page: 100,
 		});
 
-		const tasks = issues.map((issue) => ({
+		let tasks = issues.map((issue) => ({
 			id: `${issue.number}:${issue.title}`,
 			title: issue.title,
 			body: issue.body || undefined,
 			completed: false,
 		}));
+
+		// Sort by specified order if provided
+		if (this.order && this.order.length > 0) {
+			const orderMap = new Map(this.order.map((num, idx) => [num, idx]));
+			tasks = tasks
+				.filter((t) => {
+					const issueNum = Number.parseInt(t.id.split(":")[0], 10);
+					return orderMap.has(issueNum);
+				})
+				.sort((a, b) => {
+					const aNum = Number.parseInt(a.id.split(":")[0], 10);
+					const bNum = Number.parseInt(b.id.split(":")[0], 10);
+					return (orderMap.get(aNum) ?? 0) - (orderMap.get(bNum) ?? 0);
+				});
+		}
 
 		// Update cache (preserve closed count if we have it)
 		this.cache = {

--- a/cli/src/tasks/index.ts
+++ b/cli/src/tasks/index.ts
@@ -21,6 +21,8 @@ interface TaskSourceOptions {
 	repo?: string;
 	/** Label filter for GitHub source */
 	label?: string;
+	/** Ordered list of issue numbers to execute in sequence */
+	order?: number[];
 }
 
 /**
@@ -56,7 +58,7 @@ export function createTaskSource(options: TaskSourceOptions): TaskSource {
 			if (!options.repo) {
 				throw new Error("repo is required for github task source");
 			}
-			return new GitHubTaskSource(options.repo, options.label);
+			return new GitHubTaskSource(options.repo, options.label, options.order);
 
 		default:
 			throw new Error(`Unknown task source type: ${options.type}`);


### PR DESCRIPTION
## Summary

- Adds `--github-order <issues>` CLI flag that accepts comma-separated issue numbers (e.g. `--github-order 2,3,4,5,6`)
- When set, only the specified issues are executed, in the exact order given
- Without it, behavior is unchanged (issues returned in API default order)

**Motivation:** When using `--github` to pull tasks from GitHub Issues, the API returns issues newest-first. For sequential workflows where tasks have dependencies (e.g. "project setup" before "database layer" before "API routes"), you need control over execution order.

## Changes

- `cli/src/cli/args.ts` — new `--github-order` option, parsed into `number[]` with NaN filtering and empty-array coercion
- `cli/src/config/types.ts` — `githubOrder?: number[]` added to `RuntimeOptions`
- `cli/src/tasks/github.ts` — filter and sort fetched issues by the specified order, warn on missing issues, consistent `countCompleted()` filtering
- `cli/src/tasks/index.ts` — pass `order` through to `GitHubTaskSource`
- `cli/src/cli/commands/run.ts` — wire `githubOrder` into `createTaskSource`
- `README.md` — documented in GitHub Issues section and Options table

## Example

```bash
# Execute issues #2, #3, #4, #5, #6 in that exact order
ralphy --github owner/repo --github-label "task" --github-order 2,3,4,5,6 --claude
```

## Test plan

- [x] Tested manually against a real repo with 5 GitHub issues — confirmed correct execution order
- [x] Verify `--github-order` without `--github` is a no-op (flag is only read by `GitHubTaskSource`)
- [x] Verify omitting `--github-order` preserves existing behavior (guard checks `this.order && this.order.length > 0`)
- [x] Non-numeric tokens in `--github-order` are filtered out (NaN filter)
- [x] Fully invalid input (e.g. `--github-order ,,,`) coerces to `undefined`, falls back to default behavior
- [x] `countCompleted()` only counts closed issues in the order list when `--github-order` is set
- [x] Warning logged when ordered issue numbers are not found among open issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--github-order` flag to control GitHub issue execution order
> - Adds a `--github-order <issues>` CLI flag that accepts a comma-separated list of issue numbers, parsed into `options.githubOrder` in [args.ts](https://github.com/michaelshimeles/ralphy/pull/169/files#diff-b361755e0592165f9ab84b608dc2af1f5eb650d22a22623862cd4fa6c885e4b3).
> - When provided, `GitHubTaskSource` in [github.ts](https://github.com/michaelshimeles/ralphy/pull/169/files#diff-7ae4c43661366845dd4b3ef06592a4c34a502e3c135e4094d7d83a4c95ebec74) filters open issues to only those specified and sorts them to match the given order; closed issue counts are also scoped to that list.
> - Issues specified in `--github-order` that are not found among open issues trigger a `console.warn`.
> - Default behavior (newest-first from the GitHub API) is unchanged when the flag is omitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1e5a2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->