### PR TITLE
Add ability to stream agent output during loop

### DIFF
--- a/cli/src/cli/args.test.ts
+++ b/cli/src/cli/args.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "./args.ts";
+
+describe("parseArgs", () => {
+	describe("--stream-output", () => {
+		it("should default streamOutput to false", () => {
+			const { options } = parseArgs(["node", "ralphy", "some task"]);
+			expect(options.streamOutput).toBe(false);
+		});
+
+		it("should set streamOutput to true when --stream-output is passed", () => {
+			const { options } = parseArgs(["node", "ralphy", "--stream-output", "some task"]);
+			expect(options.streamOutput).toBe(true);
+		});
+
+		it("should work with other flags", () => {
+			const { options } = parseArgs([
+				"node",
+				"ralphy",
+				"--stream-output",
+				"--verbose",
+				"--dry-run",
+				"some task",
+			]);
+			expect(options.streamOutput).toBe(true);
+			expect(options.verbose).toBe(true);
+			expect(options.dryRun).toBe(true);
+		});
+	});
+});

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -56,6 +56,7 @@ export function createProgram(): Command {
 		.option("--model <name>", "Override default model for the engine")
 		.option("--sonnet", "Shortcut for --claude --model sonnet")
 		.option("--no-merge", "Skip automatic branch merging after parallel execution")
+		.option("--stream-output", "Stream raw AI output to stdout")
 		.option("-v, --verbose", "Verbose output")
 		.allowUnknownOption();
 
@@ -159,6 +160,7 @@ export function parseArgs(args: string[]): {
 		skipMerge: opts.merge === false,
 		useSandbox: opts.sandbox || false,
 		engineArgs,
+		streamOutput: opts.streamOutput || false,
 	};
 
 	return {

--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -139,6 +139,7 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 			skipMerge: options.skipMerge,
 			engineArgs: options.engineArgs,
 			syncIssue: options.syncIssue,
+			streamOutput: options.streamOutput,
 		});
 	} else {
 		result = await runSequential({
@@ -163,6 +164,7 @@ export async function runLoop(options: RuntimeOptions): Promise<void> {
 			skipMerge: options.skipMerge,
 			engineArgs: options.engineArgs,
 			syncIssue: options.syncIssue,
+			streamOutput: options.streamOutput,
 		});
 	}
 

--- a/cli/src/cli/commands/task-stream.test.ts
+++ b/cli/src/cli/commands/task-stream.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { TextStreamCallback } from "../../engines/types.ts";
+
+// Track executeStreaming calls
+const mockExecuteStreaming = mock(async () => ({
+	success: true,
+	response: "Done",
+	inputTokens: 100,
+	outputTokens: 50,
+}));
+
+mock.module("../../engines/index.ts", () => ({
+	createEngine: () => ({
+		name: "mock-engine",
+		cliCommand: "mock",
+		isAvailable: async () => true,
+		execute: mock(async () => ({
+			success: true,
+			response: "Done",
+			inputTokens: 100,
+			outputTokens: 50,
+		})),
+		executeStreaming: mockExecuteStreaming,
+	}),
+	isEngineAvailable: () => Promise.resolve(true),
+}));
+
+mock.module("../../config/loader.ts", () => ({
+	loadConfig: () => null,
+	loadProjectContext: () => "",
+	loadRules: () => [],
+	loadBoundaries: () => ({ neverTouch: [] }),
+}));
+
+mock.module("../../notifications/webhook.ts", () => ({
+	sendNotifications: async () => {},
+}));
+
+mock.module("../../config/writer.ts", () => ({
+	logTaskProgress: () => {},
+}));
+
+mock.module("../../ui/notify.ts", () => ({
+	notifyTaskComplete: () => {},
+	notifyTaskFailed: () => {},
+}));
+
+mock.module("../../execution/browser.ts", () => ({
+	isBrowserAvailable: () => false,
+	getBrowserInstructions: () => "",
+}));
+
+mock.module("../../ui/spinner.ts", () => ({
+	ProgressSpinner: class {
+		stop = mock(() => {});
+		updateStep = mock(() => {});
+		success = mock(() => {});
+		error = mock(() => {});
+	},
+}));
+
+mock.module("../../ui/logger.ts", () => ({
+	logDebug: () => {},
+	logError: () => {},
+	logInfo: () => {},
+	logSuccess: () => {},
+	logWarn: () => {},
+	setVerbose: () => {},
+	formatTokens: () => "",
+	formatDuration: (ms: number) => `${ms}ms`,
+}));
+
+mock.module("../../ui/settings.ts", () => ({
+	buildActiveSettings: () => [],
+}));
+
+mock.module("../../execution/prompt.ts", () => ({
+	buildPrompt: () => "test prompt",
+}));
+
+import type { RuntimeOptions } from "../../config/types.ts";
+import { runTask } from "./task.ts";
+
+let stdoutSpy: ReturnType<typeof spyOn>;
+let consoleSpy: ReturnType<typeof spyOn>;
+
+function baseOptions(overrides: Partial<RuntimeOptions> = {}): RuntimeOptions {
+	return {
+		skipTests: true,
+		skipLint: true,
+		aiEngine: "claude",
+		dryRun: false,
+		maxIterations: 0,
+		maxRetries: 1,
+		retryDelay: 0,
+		verbose: false,
+		branchPerTask: false,
+		baseBranch: "",
+		createPr: false,
+		draftPr: false,
+		parallel: false,
+		maxParallel: 1,
+		prdSource: "markdown",
+		prdFile: "PRD.md",
+		prdIsFolder: false,
+		githubRepo: "",
+		githubLabel: "",
+		autoCommit: false,
+		browserEnabled: "false",
+		streamOutput: false,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	stdoutSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+	consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+	mockExecuteStreaming.mockReset();
+	mockExecuteStreaming.mockImplementation(async () => ({
+		success: true,
+		response: "Done",
+		inputTokens: 100,
+		outputTokens: 50,
+	}));
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+	consoleSpy.mockRestore();
+});
+
+describe("task mode streaming", () => {
+	it("should pass text callback to executeStreaming when streamOutput is true", async () => {
+		await runTask("test task", baseOptions({ streamOutput: true }));
+
+		expect(mockExecuteStreaming).toHaveBeenCalledTimes(1);
+		const calls = mockExecuteStreaming.mock.calls;
+		const onTextArg = calls[0][4];
+		expect(onTextArg).toBeFunction();
+	});
+
+	it("should not pass text callback when streamOutput is false", async () => {
+		await runTask("test task", baseOptions({ streamOutput: false }));
+
+		expect(mockExecuteStreaming).toHaveBeenCalledTimes(1);
+		const calls = mockExecuteStreaming.mock.calls;
+		const onTextArg = calls[0][4];
+		expect(onTextArg).toBeUndefined();
+	});
+
+	it("should write streamed text directly to process.stdout", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		mockExecuteStreaming.mockImplementation(
+			async (
+				_prompt: string,
+				_workDir: string,
+				_onProgress: (step: string) => void,
+				_options?: Record<string, unknown>,
+				onText?: TextStreamCallback,
+			) => {
+				if (onText) {
+					onText("Hello ");
+					onText("from task");
+				}
+				return { success: true, response: "Done", inputTokens: 100, outputTokens: 50 };
+			},
+		);
+
+		await runTask("test task", baseOptions({ streamOutput: true }));
+
+		expect(writtenChunks).toContain("Hello ");
+		expect(writtenChunks).toContain("from task");
+	});
+
+	it("should not write streamed text when streamOutput is false", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		mockExecuteStreaming.mockImplementation(
+			async (
+				_prompt: string,
+				_workDir: string,
+				_onProgress: (step: string) => void,
+				_options?: Record<string, unknown>,
+				onText?: TextStreamCallback,
+			) => {
+				if (onText) onText("should not appear");
+				return { success: true, response: "Done", inputTokens: 100, outputTokens: 50 };
+			},
+		);
+
+		await runTask("test task", baseOptions({ streamOutput: false }));
+
+		expect(writtenChunks).not.toContain("should not appear");
+	});
+
+	it("should use process.stdout.write directly (not StreamRenderer)", async () => {
+		let capturedCallback: TextStreamCallback | undefined;
+
+		mockExecuteStreaming.mockImplementation(
+			async (
+				_prompt: string,
+				_workDir: string,
+				_onProgress: (step: string) => void,
+				_options?: Record<string, unknown>,
+				onText?: TextStreamCallback,
+			) => {
+				capturedCallback = onText;
+				return { success: true, response: "Done", inputTokens: 100, outputTokens: 50 };
+			},
+		);
+
+		await runTask("test task", baseOptions({ streamOutput: true }));
+
+		expect(capturedCallback).toBeDefined();
+		// Call the callback and verify it writes to stdout
+		capturedCallback?.("direct output");
+		expect(stdoutSpy).toHaveBeenCalledWith("direct output");
+	});
+});

--- a/cli/src/cli/commands/task.ts
+++ b/cli/src/cli/commands/task.ts
@@ -82,6 +82,7 @@ export async function runTask(task: string, options: RuntimeOptions): Promise<vo
 							spinner.updateStep(step);
 						},
 						engineOptions,
+						options.streamOutput ? (text) => process.stdout.write(text) : undefined,
 					);
 				}
 

--- a/cli/src/config/types.ts
+++ b/cli/src/config/types.ts
@@ -115,6 +115,8 @@ export interface RuntimeOptions {
 	useSandbox?: boolean;
 	/** Additional arguments to pass to the engine CLI */
 	engineArgs?: string[];
+	/** Stream raw AI output to stdout */
+	streamOutput: boolean;
 }
 
 /**
@@ -142,4 +144,5 @@ export const DEFAULT_OPTIONS: RuntimeOptions = {
 	githubLabel: "",
 	autoCommit: true,
 	browserEnabled: "auto",
+	streamOutput: false,
 };

--- a/cli/src/engines/base.test.ts
+++ b/cli/src/engines/base.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	checkForErrors,
+	extractAssistantTextFromStreamJson,
 	extractAuthenticationError,
 	formatCommandError,
 	parseStreamJsonResult,
@@ -219,6 +220,108 @@ describe("extractAuthenticationError", () => {
 		const error = extractAuthenticationError(output);
 
 		expect(error).toBeNull();
+	});
+});
+
+describe("extractAssistantTextFromStreamJson", () => {
+	it("should extract text from assistant message with content array", () => {
+		const line = `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBe("Hello world");
+	});
+
+	it("should concatenate multiple text items in content array", () => {
+		const line = `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "},{"type":"text","text":"world"}]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBe("Hello world");
+	});
+
+	it("should skip non-text content items", () => {
+		const line = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"123"},{"type":"text","text":"Some text"}]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBe("Some text");
+	});
+
+	it("should return null for non-assistant type lines", () => {
+		const line = `{"type":"result","result":"Done"}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for system type lines", () => {
+		const line = `{"type":"system","subtype":"init","model":"claude"}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for error type lines", () => {
+		const line = `{"type":"error","error":{"message":"Something failed"}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for assistant lines without content array", () => {
+		const line = `{"type":"assistant","message":{"tool":"read","name":"file.ts"}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for content array with no text items", () => {
+		const line = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"123"}]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null for non-JSON lines", () => {
+		expect(extractAssistantTextFromStreamJson("plain text")).toBeNull();
+		expect(extractAssistantTextFromStreamJson("")).toBeNull();
+		expect(extractAssistantTextFromStreamJson("  ")).toBeNull();
+	});
+
+	it("should return null for malformed JSON", () => {
+		const result = extractAssistantTextFromStreamJson("{invalid json}");
+
+		expect(result).toBeNull();
+	});
+
+	it("should handle empty content array", () => {
+		const line = `{"type":"assistant","message":{"content":[]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBeNull();
+	});
+
+	it("should handle text with special characters", () => {
+		const line = `{"type":"assistant","message":{"content":[{"type":"text","text":"Line 1\\nLine 2\\ttab"}]}}`;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBe("Line 1\nLine 2\ttab");
+	});
+
+	it("should handle whitespace-padded lines", () => {
+		const line = `  {"type":"assistant","message":{"content":[{"type":"text","text":"trimmed"}]}}  `;
+
+		const result = extractAssistantTextFromStreamJson(line);
+
+		expect(result).toBe("trimmed");
 	});
 });
 

--- a/cli/src/engines/base.ts
+++ b/cli/src/engines/base.ts
@@ -345,6 +345,41 @@ export async function execCommandStreaming(
 }
 
 /**
+ * Extract assistant text from a stream-json line.
+ * Parses lines with type "assistant" and extracts text from message.content array.
+ * Returns concatenated text or null if the line is not an assistant text message.
+ */
+export function extractAssistantTextFromStreamJson(line: string): string | null {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("{")) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse(trimmed);
+		if (parsed.type !== "assistant") {
+			return null;
+		}
+
+		const content = parsed.message?.content;
+		if (!Array.isArray(content)) {
+			return null;
+		}
+
+		const texts: string[] = [];
+		for (const item of content) {
+			if (item.type === "text" && typeof item.text === "string") {
+				texts.push(item.text);
+			}
+		}
+
+		return texts.length > 0 ? texts.join("") : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Check if a file path looks like a test file
  */
 function isTestFile(filePath: string): boolean {

--- a/cli/src/engines/claude.test.ts
+++ b/cli/src/engines/claude.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { ClaudeEngine } from "./claude.ts";
 import type { TextStreamCallback } from "./types.ts";
 

--- a/cli/src/engines/claude.test.ts
+++ b/cli/src/engines/claude.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { ClaudeEngine } from "./claude.ts";
+import type { TextStreamCallback } from "./types.ts";
+
+// Mock the base module to control execCommandStreaming behavior
+const mockExecCommandStreaming = mock();
+
+mock.module("./base.ts", () => {
+	const actual = require("./base.ts");
+	return {
+		...actual,
+		execCommandStreaming: mockExecCommandStreaming,
+	};
+});
+
+describe("ClaudeEngine.executeStreaming", () => {
+	let engine: ClaudeEngine;
+
+	beforeEach(() => {
+		engine = new ClaudeEngine();
+		mockExecCommandStreaming.mockReset();
+	});
+
+	it("should call onText with extracted assistant text from stream lines", async () => {
+		const textChunks: string[] = [];
+		const onText: TextStreamCallback = (text) => textChunks.push(text);
+		const onProgress = mock();
+
+		mockExecCommandStreaming.mockImplementation(
+			(_cmd: string, _args: string[], _workDir: string, onLine: (line: string) => void) => {
+				// Simulate stream-json lines
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: { content: [{ type: "text", text: "Hello world" }] },
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: { content: [{ type: "text", text: " more text" }] },
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "result",
+						result: "done",
+						input_tokens: 10,
+						output_tokens: 20,
+					}),
+				);
+				return Promise.resolve({ exitCode: 0 });
+			},
+		);
+
+		await engine.executeStreaming("test prompt", "/tmp", onProgress, undefined, onText);
+
+		expect(textChunks).toEqual(["Hello world", " more text"]);
+	});
+
+	it("should not call onText for non-assistant lines", async () => {
+		const textChunks: string[] = [];
+		const onText: TextStreamCallback = (text) => textChunks.push(text);
+		const onProgress = mock();
+
+		mockExecCommandStreaming.mockImplementation(
+			(_cmd: string, _args: string[], _workDir: string, onLine: (line: string) => void) => {
+				onLine(JSON.stringify({ type: "system", message: "starting" }));
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: { content: [{ type: "text", text: "actual text" }] },
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "result",
+						result: "done",
+						input_tokens: 5,
+						output_tokens: 10,
+					}),
+				);
+				return Promise.resolve({ exitCode: 0 });
+			},
+		);
+
+		await engine.executeStreaming("test", "/tmp", onProgress, undefined, onText);
+
+		expect(textChunks).toEqual(["actual text"]);
+	});
+
+	it("should work without onText callback", async () => {
+		const onProgress = mock();
+
+		mockExecCommandStreaming.mockImplementation(
+			(_cmd: string, _args: string[], _workDir: string, onLine: (line: string) => void) => {
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: { content: [{ type: "text", text: "Hello" }] },
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "result",
+						result: "done",
+						input_tokens: 5,
+						output_tokens: 10,
+					}),
+				);
+				return Promise.resolve({ exitCode: 0 });
+			},
+		);
+
+		// Should not throw when onText is not provided
+		const result = await engine.executeStreaming("test", "/tmp", onProgress);
+		expect(result.success).toBe(true);
+	});
+
+	it("should still report progress steps when onText is provided", async () => {
+		const textChunks: string[] = [];
+		const onText: TextStreamCallback = (text) => textChunks.push(text);
+		const progressSteps: string[] = [];
+		const onProgress = (step: string) => progressSteps.push(step);
+
+		mockExecCommandStreaming.mockImplementation(
+			(_cmd: string, _args: string[], _workDir: string, onLine: (line: string) => void) => {
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: {
+							content: [
+								{
+									type: "tool_use",
+									name: "Read",
+								},
+							],
+						},
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "assistant",
+						message: { content: [{ type: "text", text: "response" }] },
+					}),
+				);
+				onLine(
+					JSON.stringify({
+						type: "result",
+						result: "done",
+						input_tokens: 5,
+						output_tokens: 10,
+					}),
+				);
+				return Promise.resolve({ exitCode: 0 });
+			},
+		);
+
+		await engine.executeStreaming("test", "/tmp", onProgress, undefined, onText);
+
+		expect(textChunks).toEqual(["response"]);
+	});
+});

--- a/cli/src/engines/claude.ts
+++ b/cli/src/engines/claude.ts
@@ -4,10 +4,11 @@ import {
 	detectStepFromOutput,
 	execCommand,
 	execCommandStreaming,
+	extractAssistantTextFromStreamJson,
 	formatCommandError,
 	parseStreamJsonResult,
 } from "./base.ts";
-import type { AIResult, EngineOptions, ProgressCallback } from "./types.ts";
+import type { AIResult, EngineOptions, ProgressCallback, TextStreamCallback } from "./types.ts";
 
 const isWindows = process.platform === "win32";
 
@@ -87,6 +88,7 @@ export class ClaudeEngine extends BaseAIEngine {
 		workDir: string,
 		onProgress: ProgressCallback,
 		options?: EngineOptions,
+		onText?: TextStreamCallback,
 	): Promise<AIResult> {
 		const args = ["--dangerously-skip-permissions", "--verbose", "--output-format", "stream-json"];
 		if (options?.modelOverride) {
@@ -120,6 +122,14 @@ export class ClaudeEngine extends BaseAIEngine {
 				const step = detectStepFromOutput(line);
 				if (step) {
 					onProgress(step);
+				}
+
+				// Stream assistant text to callback
+				if (onText) {
+					const text = extractAssistantTextFromStreamJson(line);
+					if (text) {
+						onText(text);
+					}
 				}
 			},
 			undefined,

--- a/cli/src/engines/types.test.ts
+++ b/cli/src/engines/types.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import type { ProgressCallback, TextStreamCallback } from "./types.ts";
+
+describe("TextStreamCallback", () => {
+	it("should accept a string argument and return void", () => {
+		const callback: TextStreamCallback = (_text: string) => {};
+		callback("hello world");
+	});
+
+	it("should work as a streaming text collector", () => {
+		const chunks: string[] = [];
+		const callback: TextStreamCallback = (text) => {
+			chunks.push(text);
+		};
+
+		callback("Hello ");
+		callback("world");
+		callback("!");
+
+		expect(chunks).toEqual(["Hello ", "world", "!"]);
+	});
+
+	it("should be assignable to the same signature as ProgressCallback", () => {
+		const textCb: TextStreamCallback = (text) => text;
+		const progressCb: ProgressCallback = (step) => step;
+
+		// Both should accept string and return void
+		const fn = (cb: (s: string) => void) => cb("test");
+		fn(textCb);
+		fn(progressCb);
+	});
+});

--- a/cli/src/engines/types.ts
+++ b/cli/src/engines/types.ts
@@ -49,6 +49,7 @@ export interface AIEngine {
 		workDir: string,
 		onProgress: ProgressCallback,
 		options?: EngineOptions,
+		onText?: TextStreamCallback,
 	): Promise<AIResult>;
 }
 

--- a/cli/src/engines/types.ts
+++ b/cli/src/engines/types.ts
@@ -27,6 +27,11 @@ export interface EngineOptions {
 export type ProgressCallback = (step: string) => void;
 
 /**
+ * Callback for streaming raw text output from engine execution
+ */
+export type TextStreamCallback = (text: string) => void;
+
+/**
  * AI Engine interface - one per AI tool
  */
 export interface AIEngine {

--- a/cli/src/execution/parallel-stream.test.ts
+++ b/cli/src/execution/parallel-stream.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { AIEngine, AIResult, TextStreamCallback } from "../engines/types.ts";
+import type { TaskSource } from "../tasks/types.ts";
+
+// Mock git modules to avoid real git operations
+mock.module("simple-git", () => ({
+	default: () => ({
+		status: async () => ({ files: [], not_added: [] }),
+		stash: async () => {},
+	}),
+}));
+
+mock.module("../git/branch.ts", () => ({
+	getCurrentBranch: async () => "main",
+	returnToBaseBranch: async () => {},
+}));
+
+mock.module("../git/worktree.ts", () => ({
+	canUseWorktrees: () => true,
+	getWorktreeBase: () => "/tmp/worktrees",
+	createAgentWorktree: async (_title: string, agentNum: number) => ({
+		worktreeDir: `/tmp/worktrees/agent-${agentNum}`,
+		branchName: `agent-${agentNum}`,
+	}),
+	cleanupAgentWorktree: async () => ({ leftInPlace: false }),
+}));
+
+mock.module("../git/merge.ts", () => ({
+	analyzePreMerge: async () => ({ branch: "", fileCount: 0 }),
+	sortByConflictLikelihood: (a: unknown[]) => a,
+	mergeAgentBranch: async () => ({ success: true }),
+	deleteLocalBranch: async () => true,
+	abortMerge: async () => {},
+}));
+
+mock.module("../git/issue-sync.ts", () => ({
+	syncPrdToIssue: async () => {},
+}));
+
+mock.module("../config/loader.ts", () => ({
+	PROGRESS_FILE: ".ralphy/progress.txt",
+	RALPHY_DIR: ".ralphy",
+}));
+
+mock.module("../config/writer.ts", () => ({
+	logTaskProgress: () => {},
+}));
+
+mock.module("../ui/logger.ts", () => ({
+	logDebug: () => {},
+	logError: () => {},
+	logInfo: () => {},
+	logSuccess: () => {},
+	logWarn: () => {},
+	setVerbose: () => {},
+	formatTokens: () => "",
+	formatDuration: (ms: number) => `${ms}ms`,
+}));
+
+mock.module("../ui/notify.ts", () => ({
+	notifyTaskComplete: () => {},
+	notifyTaskFailed: () => {},
+}));
+
+mock.module("./deferred.ts", () => ({
+	clearDeferredTask: () => {},
+	recordDeferredTask: () => 0,
+}));
+
+mock.module("./prompt.ts", () => ({
+	buildParallelPrompt: () => "test prompt",
+}));
+
+mock.module("./conflict-resolution.ts", () => ({
+	resolveConflictsWithAI: async () => false,
+}));
+
+mock.module("./sandbox.ts", () => ({
+	getSandboxBase: () => "/tmp/sandboxes",
+	createSandbox: async () => ({ symlinksCreated: 0, filesCopied: 0 }),
+	getModifiedFiles: async () => [],
+	cleanupSandbox: async () => {},
+}));
+
+mock.module("./sandbox-git.ts", () => ({
+	commitSandboxChanges: async () => ({ success: true, branchName: "test", filesCommitted: 0 }),
+}));
+
+// Stub fs calls used by parallel.ts for PRD copying
+mock.module("node:fs", () => ({
+	existsSync: () => true,
+	copyFileSync: () => {},
+	cpSync: () => {},
+	mkdirSync: () => {},
+}));
+
+import { runParallel } from "./parallel.ts";
+import type { ExecutionOptions } from "./sequential.ts";
+
+const OK_RESULT: AIResult = {
+	success: true,
+	response: "Done",
+	inputTokens: 100,
+	outputTokens: 50,
+};
+
+function createMockEngine(opts?: {
+	onText?: (cb: TextStreamCallback) => void;
+}): AIEngine {
+	return {
+		name: "mock",
+		cliCommand: "mock",
+		isAvailable: async () => true,
+		execute: mock(async () => OK_RESULT),
+		executeStreaming: mock(
+			async (
+				_prompt: string,
+				_workDir: string,
+				_onProgress: (step: string) => void,
+				_options?: Record<string, unknown>,
+				onText?: TextStreamCallback,
+			) => {
+				if (onText && opts?.onText) {
+					opts.onText(onText);
+				}
+				return OK_RESULT;
+			},
+		),
+	};
+}
+
+function createMockTaskSource(taskCount = 1): TaskSource {
+	const tasks = Array.from({ length: taskCount }, (_, i) => ({
+		id: `task-${i}`,
+		title: `Task ${i}`,
+		body: `Do task ${i}`,
+	}));
+	const completed = new Set<string>();
+
+	return {
+		type: "inline" as const,
+		getNextTask: mock(async () => {
+			const next = tasks.find((t) => !completed.has(t.id));
+			return next || null;
+		}),
+		markComplete: mock(async (id: string) => {
+			completed.add(id);
+		}),
+		countRemaining: mock(async () => tasks.filter((t) => !completed.has(t.id)).length),
+		getAllTasks: mock(async () => tasks.filter((t) => !completed.has(t.id))),
+	};
+}
+
+type ParallelOptions = ExecutionOptions & {
+	maxParallel: number;
+	prdSource: string;
+	prdFile: string;
+	prdIsFolder?: boolean;
+};
+
+function baseOptions(overrides: Partial<ParallelOptions> = {}): ParallelOptions {
+	return {
+		engine: createMockEngine(),
+		taskSource: createMockTaskSource(),
+		workDir: "/tmp/test",
+		skipTests: true,
+		skipLint: true,
+		dryRun: false,
+		maxIterations: 10,
+		maxRetries: 1,
+		retryDelay: 0,
+		branchPerTask: false,
+		baseBranch: "main",
+		createPr: false,
+		draftPr: false,
+		autoCommit: false,
+		browserEnabled: "false",
+		streamOutput: false,
+		maxParallel: 4,
+		prdSource: "markdown",
+		prdFile: "PRD.md",
+		...overrides,
+	};
+}
+
+let stdoutSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+	stdoutSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+});
+
+describe("parallel execution streaming", () => {
+	it("should use executeStreaming when streamOutput is true", async () => {
+		const engine = createMockEngine();
+
+		await runParallel(baseOptions({ engine, streamOutput: true }));
+
+		expect(engine.executeStreaming).toHaveBeenCalledTimes(1);
+		expect(engine.execute).not.toHaveBeenCalled();
+	});
+
+	it("should use execute when streamOutput is false", async () => {
+		const engine = createMockEngine();
+
+		await runParallel(baseOptions({ engine, streamOutput: false }));
+
+		expect(engine.execute).toHaveBeenCalledTimes(1);
+		expect(engine.executeStreaming).not.toHaveBeenCalled();
+	});
+
+	it("should pass text callback with agent prefix when streaming", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("hello world");
+			},
+		});
+
+		await runParallel(baseOptions({ engine, streamOutput: true }));
+
+		const agentOutput = writtenChunks.find((c) => c.includes("[agent 1]"));
+		expect(agentOutput).toBeDefined();
+		expect(agentOutput).toContain("hello world");
+	});
+
+	it("should not write to stdout when streamOutput is false", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("should not appear");
+			},
+		});
+
+		await runParallel(baseOptions({ engine, streamOutput: false }));
+
+		const agentOutput = writtenChunks.find((c) => c.includes("[agent"));
+		expect(agentOutput).toBeUndefined();
+	});
+
+	it("should prefix output with correct agent number for multiple tasks", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		let callCount = 0;
+		const engine = createMockEngine({
+			onText: (cb) => {
+				callCount++;
+				cb(`output ${callCount}`);
+			},
+		});
+
+		await runParallel(
+			baseOptions({
+				engine,
+				taskSource: createMockTaskSource(2),
+				maxParallel: 4,
+				streamOutput: true,
+			}),
+		);
+
+		expect(engine.executeStreaming).toHaveBeenCalledTimes(2);
+		const agent1Output = writtenChunks.find((c) => c.includes("[agent 1]"));
+		const agent2Output = writtenChunks.find((c) => c.includes("[agent 2]"));
+		expect(agent1Output).toBeDefined();
+		expect(agent2Output).toBeDefined();
+	});
+
+	it("should fall back to execute when engine has no executeStreaming", async () => {
+		const engine: AIEngine = {
+			name: "mock",
+			cliCommand: "mock",
+			isAvailable: async () => true,
+			execute: mock(async () => OK_RESULT),
+		};
+
+		await runParallel(baseOptions({ engine, streamOutput: true }));
+
+		expect(engine.execute).toHaveBeenCalledTimes(1);
+	});
+});

--- a/cli/src/execution/parallel.ts
+++ b/cli/src/execution/parallel.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import simpleGit from "simple-git";
 import { PROGRESS_FILE, RALPHY_DIR } from "../config/loader.ts";
 import { logTaskProgress } from "../config/writer.ts";
-import type { AIEngine, AIResult } from "../engines/types.ts";
+import type { AIEngine, AIResult, TextStreamCallback } from "../engines/types.ts";
 import { getCurrentBranch, returnToBaseBranch } from "../git/branch.ts";
 import { syncPrdToIssue } from "../git/issue-sync.ts";
 import {
@@ -61,6 +61,7 @@ async function runAgentInWorktree(
 	browserEnabled: "auto" | "true" | "false",
 	modelOverride?: string,
 	engineArgs?: string[],
+	onText?: TextStreamCallback,
 ): Promise<ParallelAgentResult> {
 	let worktreeDir = "";
 	let branchName = "";
@@ -117,6 +118,15 @@ async function runAgentInWorktree(
 		};
 		const result = await withRetry(
 			async () => {
+				if (onText && engine.executeStreaming) {
+					return await engine.executeStreaming(
+						prompt,
+						worktreeDir,
+						() => {},
+						engineOptions,
+						onText,
+					);
+				}
 				const res = await engine.execute(prompt, worktreeDir, engineOptions);
 				if (!res.success && res.error && isRetryableError(res.error)) {
 					throw new Error(res.error);
@@ -155,6 +165,7 @@ async function runAgentInSandbox(
 	browserEnabled: "auto" | "true" | "false",
 	modelOverride?: string,
 	engineArgs?: string[],
+	onText?: TextStreamCallback,
 ): Promise<ParallelAgentResult> {
 	const uniqueSuffix = Math.random().toString(36).substring(2, 8);
 	const sandboxDir = join(sandboxBase, `agent-${agentNum}-${uniqueSuffix}`);
@@ -211,6 +222,9 @@ async function runAgentInSandbox(
 		};
 		const result = await withRetry(
 			async () => {
+				if (onText && engine.executeStreaming) {
+					return await engine.executeStreaming(prompt, sandboxDir, () => {}, engineOptions, onText);
+				}
 				const res = await engine.execute(prompt, sandboxDir, engineOptions);
 				if (!res.success && res.error && isRetryableError(res.error)) {
 					throw new Error(res.error);
@@ -267,6 +281,7 @@ export async function runParallel(
 		useSandbox = false,
 		engineArgs,
 		syncIssue,
+		streamOutput,
 	} = options;
 
 	const shouldFallbackToSandbox = (error: string | undefined): boolean => {
@@ -381,12 +396,17 @@ export async function runParallel(
 		// Run agents in parallel (using sandbox or worktree mode)
 		const promises = batch.map((task) => {
 			globalAgentNum++;
+			const agentNum = globalAgentNum;
+
+			const onText: TextStreamCallback | undefined = streamOutput
+				? (text) => process.stdout.write(`[agent ${agentNum}] ${text}`)
+				: undefined;
 
 			const runInSandbox = () =>
 				runAgentInSandbox(
 					engine,
 					task,
-					globalAgentNum,
+					agentNum,
 					getSandboxBase(workDir),
 					workDir,
 					prdSource,
@@ -399,6 +419,7 @@ export async function runParallel(
 					browserEnabled,
 					modelOverride,
 					engineArgs,
+					onText,
 				);
 
 			if (effectiveUseSandbox) {
@@ -408,7 +429,7 @@ export async function runParallel(
 			return runAgentInWorktree(
 				engine,
 				task,
-				globalAgentNum,
+				agentNum,
 				baseBranch,
 				isolationBase,
 				workDir,
@@ -422,9 +443,10 @@ export async function runParallel(
 				browserEnabled,
 				modelOverride,
 				engineArgs,
+				onText,
 			).then((res) => {
 				if (shouldFallbackToSandbox(res.error)) {
-					logWarn(`Agent ${globalAgentNum}: Worktree unavailable, retrying in sandbox mode.`);
+					logWarn(`Agent ${agentNum}: Worktree unavailable, retrying in sandbox mode.`);
 					if (res.worktreeDir) {
 						cleanupAgentWorktree(res.worktreeDir, res.branchName, workDir).catch(() => {
 							// Ignore cleanup failures during fallback

--- a/cli/src/execution/sequential-stream.test.ts
+++ b/cli/src/execution/sequential-stream.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { AIEngine, AIResult, TextStreamCallback } from "../engines/types.ts";
+import type { TaskSource } from "../tasks/types.ts";
+
+// Mock spinner to avoid nanospinner side effects
+mock.module("../ui/spinner.ts", () => ({
+	ProgressSpinner: class {
+		stop = mock(() => {});
+		updateStep = mock(() => {});
+		success = mock(() => {});
+		error = mock(() => {});
+	},
+}));
+
+// Mock logger to suppress output
+mock.module("../ui/logger.ts", () => ({
+	logDebug: () => {},
+	logError: () => {},
+	logInfo: () => {},
+	logSuccess: () => {},
+	logWarn: () => {},
+	setVerbose: () => {},
+	formatTokens: () => "",
+	formatDuration: (ms: number) => `${ms}ms`,
+}));
+
+// Mock other side-effect modules
+mock.module("../ui/notify.ts", () => ({
+	notifyTaskComplete: () => {},
+	notifyTaskFailed: () => {},
+}));
+
+mock.module("../config/writer.ts", () => ({
+	logTaskProgress: () => {},
+}));
+
+mock.module("./deferred.ts", () => ({
+	clearDeferredTask: () => {},
+	recordDeferredTask: () => 0,
+}));
+
+mock.module("./prompt.ts", () => ({
+	buildPrompt: () => "test prompt",
+}));
+
+import { type ExecutionOptions, runSequential } from "./sequential.ts";
+
+let stdoutSpy: ReturnType<typeof spyOn>;
+let consoleSpy: ReturnType<typeof spyOn>;
+
+const OK_RESULT: AIResult = {
+	success: true,
+	response: "Done",
+	inputTokens: 100,
+	outputTokens: 50,
+};
+
+function createMockEngine(opts?: {
+	onText?: (cb: TextStreamCallback) => void;
+}): AIEngine {
+	return {
+		name: "mock",
+		cliCommand: "mock",
+		isAvailable: async () => true,
+		execute: mock(async () => OK_RESULT),
+		executeStreaming: mock(
+			async (
+				_prompt: string,
+				_workDir: string,
+				_onProgress: (step: string) => void,
+				_options?: Record<string, unknown>,
+				onText?: TextStreamCallback,
+			) => {
+				if (onText && opts?.onText) {
+					opts.onText(onText);
+				}
+				return OK_RESULT;
+			},
+		),
+	};
+}
+
+function createMockTaskSource(taskCount = 1): TaskSource {
+	let calls = 0;
+	const tasks = Array.from({ length: taskCount }, (_, i) => ({
+		id: `task-${i}`,
+		title: `Task ${i}`,
+		body: `Do task ${i}`,
+	}));
+
+	return {
+		type: "inline" as const,
+		getNextTask: mock(async () => {
+			if (calls >= tasks.length) return null;
+			return tasks[calls++];
+		}),
+		markComplete: mock(async () => {}),
+		countRemaining: mock(async () => Math.max(0, tasks.length - calls)),
+	};
+}
+
+function baseOptions(overrides: Partial<ExecutionOptions> = {}): ExecutionOptions {
+	return {
+		engine: createMockEngine(),
+		taskSource: createMockTaskSource(),
+		workDir: "/tmp/test",
+		skipTests: true,
+		skipLint: true,
+		dryRun: false,
+		maxIterations: 10,
+		maxRetries: 1,
+		retryDelay: 0,
+		branchPerTask: false,
+		baseBranch: "main",
+		createPr: false,
+		draftPr: false,
+		autoCommit: false,
+		browserEnabled: "false",
+		streamOutput: false,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	stdoutSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+	consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	stdoutSpy.mockRestore();
+	consoleSpy.mockRestore();
+});
+
+describe("sequential execution streaming", () => {
+	it("should pass text callback to executeStreaming when streamOutput is true", async () => {
+		let receivedCallback: TextStreamCallback | undefined;
+		const engine = createMockEngine({
+			onText: (cb) => {
+				receivedCallback = cb;
+			},
+		});
+
+		await runSequential(baseOptions({ engine, streamOutput: true }));
+
+		expect(engine.executeStreaming).toHaveBeenCalledTimes(1);
+		expect(receivedCallback).toBeDefined();
+	});
+
+	it("should not pass text callback when streamOutput is false", async () => {
+		const engine = createMockEngine();
+
+		await runSequential(baseOptions({ engine, streamOutput: false }));
+
+		expect(engine.executeStreaming).toHaveBeenCalledTimes(1);
+		const calls = (engine.executeStreaming as ReturnType<typeof mock>).mock.calls;
+		const onTextArg = calls[0][4];
+		expect(onTextArg).toBeUndefined();
+	});
+
+	it("should stream text to stdout via StreamRenderer when streamOutput is true", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("Hello ");
+				cb("World");
+			},
+		});
+
+		await runSequential(baseOptions({ engine, streamOutput: true }));
+
+		expect(writtenChunks).toContain("Hello ");
+		expect(writtenChunks).toContain("World");
+	});
+
+	it("should not stream text to stdout when streamOutput is false", async () => {
+		const writtenChunks: string[] = [];
+		stdoutSpy.mockImplementation((chunk: string | Uint8Array) => {
+			writtenChunks.push(String(chunk));
+			return true;
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("Should not appear");
+			},
+		});
+
+		await runSequential(baseOptions({ engine, streamOutput: false }));
+
+		expect(writtenChunks).not.toContain("Should not appear");
+	});
+
+	it("should show stream borders when streamOutput is true", async () => {
+		const loggedLines: string[] = [];
+		consoleSpy.mockImplementation((...args: unknown[]) => {
+			loggedLines.push(args.map(String).join(" "));
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("streamed text");
+			},
+		});
+
+		await runSequential(baseOptions({ engine, streamOutput: true }));
+
+		const borders = loggedLines.filter((l) => l.includes("─"));
+		expect(borders.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("should use stream.success on completion when streaming", async () => {
+		const loggedLines: string[] = [];
+		consoleSpy.mockImplementation((...args: unknown[]) => {
+			loggedLines.push(args.map(String).join(" "));
+		});
+
+		const engine = createMockEngine({
+			onText: (cb) => {
+				cb("output");
+			},
+		});
+
+		await runSequential(baseOptions({ engine, streamOutput: true }));
+
+		const successLine = loggedLines.find((l) => l.includes("✔"));
+		expect(successLine).toBeDefined();
+	});
+
+	it("should use stream.error on failure when streaming", async () => {
+		const loggedLines: string[] = [];
+		consoleSpy.mockImplementation((...args: unknown[]) => {
+			loggedLines.push(args.map(String).join(" "));
+		});
+
+		const failEngine: AIEngine = {
+			name: "mock",
+			cliCommand: "mock",
+			isAvailable: async () => true,
+			execute: mock(async () => ({
+				...OK_RESULT,
+				success: false,
+				error: "Something broke",
+			})),
+			executeStreaming: mock(
+				async (
+					_prompt: string,
+					_workDir: string,
+					_onProgress: (step: string) => void,
+					_options?: Record<string, unknown>,
+					onText?: TextStreamCallback,
+				) => {
+					if (onText) onText("partial output");
+					return { ...OK_RESULT, success: false, error: "Something broke" };
+				},
+			),
+		};
+
+		await runSequential(baseOptions({ engine: failEngine, streamOutput: true }));
+
+		const errorLine = loggedLines.find((l) => l.includes("✖"));
+		expect(errorLine).toBeDefined();
+	});
+
+	it("should handle multiple tasks with streaming", async () => {
+		let callCount = 0;
+		const engine = createMockEngine({
+			onText: (cb) => {
+				callCount++;
+				cb(`task ${callCount} output`);
+			},
+		});
+
+		await runSequential(
+			baseOptions({
+				engine,
+				taskSource: createMockTaskSource(3),
+				streamOutput: true,
+			}),
+		);
+
+		expect(engine.executeStreaming).toHaveBeenCalledTimes(3);
+		expect(callCount).toBe(3);
+	});
+});

--- a/cli/src/execution/sequential.ts
+++ b/cli/src/execution/sequential.ts
@@ -7,6 +7,7 @@ import type { Task, TaskSource } from "../tasks/types.ts";
 import { logDebug, logError, logInfo, logSuccess, logWarn } from "../ui/logger.ts";
 import { notifyTaskComplete, notifyTaskFailed } from "../ui/notify.ts";
 import { ProgressSpinner } from "../ui/spinner.ts";
+import { StreamRenderer } from "../ui/stream.ts";
 import { clearDeferredTask, recordDeferredTask } from "./deferred.ts";
 import { buildPrompt } from "./prompt.ts";
 import { isFatalError, isRetryableError, sleep, withRetry } from "./retry.ts";
@@ -128,8 +129,10 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 			prdFile: options.prdFile,
 		});
 
-		// Execute with spinner
+		// Execute with spinner and optional stream renderer
 		const spinner = new ProgressSpinner(task.title, activeSettings);
+		const stream = streamOutput ? new StreamRenderer(spinner) : null;
+		const showError = (msg: string) => (stream ? stream.error(msg) : spinner.error(msg));
 		let aiResult: AIResult | null = null;
 
 		if (dryRun) {
@@ -153,7 +156,7 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 									spinner.updateStep(step);
 								},
 								engineOptions,
-								streamOutput ? (text) => process.stdout.write(text) : undefined,
+								stream ? (text) => stream.write(text) : undefined,
 							);
 						}
 
@@ -175,7 +178,11 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 				);
 
 				if (aiResult.success) {
-					spinner.success(undefined, true); // Show timing breakdown
+					if (stream) {
+						stream.success();
+					} else {
+						spinner.success(undefined, true); // Show timing breakdown
+					}
 					result.totalInputTokens += aiResult.inputTokens;
 					result.totalOutputTokens += aiResult.outputTokens;
 
@@ -211,7 +218,7 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 					const errMsg = aiResult.error || "Unknown error";
 					if (isRetryableError(errMsg)) {
 						const deferrals = recordDeferredTask(taskSource.type, task, workDir, options.prdFile);
-						spinner.error(errMsg);
+						showError(errMsg);
 						if (deferrals >= maxRetries) {
 							logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${errMsg}`);
 							logTaskProgress(task.title, "failed", workDir);
@@ -226,14 +233,14 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 						}
 					} else if (isFatalError(errMsg)) {
 						// Fatal error (auth, config) - abort all remaining tasks
-						spinner.error(errMsg);
+						showError(errMsg);
 						logError(`Fatal error: ${errMsg}`);
 						logError("Aborting remaining tasks due to configuration/authentication issue.");
 						result.tasksFailed++;
 						notifyTaskFailed(task.title, errMsg);
 						return result; // Exit immediately
 					} else {
-						spinner.error(errMsg);
+						showError(errMsg);
 						logTaskProgress(task.title, "failed", workDir);
 						result.tasksFailed++;
 						notifyTaskFailed(task.title, errMsg);
@@ -246,7 +253,7 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 				const errorMsg = error instanceof Error ? error.message : String(error);
 				if (isRetryableError(errorMsg)) {
 					const deferrals = recordDeferredTask(taskSource.type, task, workDir, options.prdFile);
-					spinner.error(errorMsg);
+					showError(errorMsg);
 					if (deferrals >= maxRetries) {
 						logError(`Task "${task.title}" failed after ${deferrals} deferrals: ${errorMsg}`);
 						logTaskProgress(task.title, "failed", workDir);
@@ -261,14 +268,14 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 					}
 				} else if (isFatalError(errorMsg)) {
 					// Fatal error (auth, config) - abort all remaining tasks
-					spinner.error(errorMsg);
+					showError(errorMsg);
 					logError(`Fatal error: ${errorMsg}`);
 					logError("Aborting remaining tasks due to configuration/authentication issue.");
 					result.tasksFailed++;
 					notifyTaskFailed(task.title, errorMsg);
 					return result; // Exit immediately
 				} else {
-					spinner.error(errorMsg);
+					showError(errorMsg);
 					logTaskProgress(task.title, "failed", workDir);
 					result.tasksFailed++;
 					notifyTaskFailed(task.title, errorMsg);

--- a/cli/src/execution/sequential.ts
+++ b/cli/src/execution/sequential.ts
@@ -40,6 +40,8 @@ export interface ExecutionOptions {
 	engineArgs?: string[];
 	/** GitHub issue number to sync PRD with on each iteration */
 	syncIssue?: number;
+	/** Stream raw AI output to stdout */
+	streamOutput?: boolean;
 }
 
 export interface ExecutionResult {
@@ -73,6 +75,7 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 		modelOverride,
 		engineArgs,
 		syncIssue,
+		streamOutput,
 	} = options;
 
 	const result: ExecutionResult = {
@@ -150,6 +153,7 @@ export async function runSequential(options: ExecutionOptions): Promise<Executio
 									spinner.updateStep(step);
 								},
 								engineOptions,
+								streamOutput ? (text) => process.stdout.write(text) : undefined,
 							);
 						}
 

--- a/cli/src/ui/index.ts
+++ b/cli/src/ui/index.ts
@@ -1,4 +1,5 @@
 export * from "./logger.ts";
 export * from "./spinner.ts";
+export * from "./stream.ts";
 export * from "./notify.ts";
 export * from "./settings.ts";

--- a/cli/src/ui/settings.test.ts
+++ b/cli/src/ui/settings.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_OPTIONS } from "../config/types.ts";
+import { buildActiveSettings } from "./settings.ts";
+
+describe("buildActiveSettings", () => {
+	it("should include stream when streamOutput is true", () => {
+		const settings = buildActiveSettings({ ...DEFAULT_OPTIONS, streamOutput: true });
+		expect(settings).toContain("stream");
+	});
+
+	it("should not include stream when streamOutput is false", () => {
+		const settings = buildActiveSettings({ ...DEFAULT_OPTIONS, streamOutput: false });
+		expect(settings).not.toContain("stream");
+	});
+});

--- a/cli/src/ui/settings.ts
+++ b/cli/src/ui/settings.ts
@@ -20,6 +20,7 @@ export function buildActiveSettings(options: RuntimeOptions): string[] {
 	if (options.createPr) activeSettings.push("pr");
 	if (options.parallel) activeSettings.push("parallel");
 	if (!options.autoCommit) activeSettings.push("no-commit");
+	if (options.streamOutput) activeSettings.push("stream");
 
 	return activeSettings;
 }

--- a/cli/src/ui/stream.test.ts
+++ b/cli/src/ui/stream.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { StreamRenderer } from "./stream.ts";
+
+// Minimal mock that satisfies the ProgressSpinner interface used by StreamRenderer
+function createMockSpinner() {
+	return {
+		stop: mock(() => {}),
+		updateStep: mock(() => {}),
+		success: mock(() => {}),
+		error: mock(() => {}),
+	};
+}
+
+describe("StreamRenderer", () => {
+	let stdoutWrite: ReturnType<typeof spyOn>;
+	let consoleLog: ReturnType<typeof spyOn>;
+	let written: string[];
+	let logged: string[];
+
+	beforeEach(() => {
+		written = [];
+		logged = [];
+		stdoutWrite = spyOn(process.stdout, "write").mockImplementation(
+			(chunk: string | Uint8Array) => {
+				written.push(String(chunk));
+				return true;
+			},
+		);
+		consoleLog = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logged.push(args.map(String).join(" "));
+		});
+	});
+
+	afterEach(() => {
+		stdoutWrite.mockRestore();
+		consoleLog.mockRestore();
+	});
+
+	it("should stop spinner on first write", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		expect(spinner.stop).not.toHaveBeenCalled();
+		renderer.write("hello");
+		expect(spinner.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("should print border on first write", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("hello");
+
+		// First console.log is the top border
+		expect(logged.length).toBeGreaterThanOrEqual(1);
+		expect(logged[0]).toContain("─");
+	});
+
+	it("should write text to stdout", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("hello ");
+		renderer.write("world");
+
+		expect(written).toContain("hello ");
+		expect(written).toContain("world");
+	});
+
+	it("should only stop spinner once for multiple writes", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("a");
+		renderer.write("b");
+		renderer.write("c");
+
+		expect(spinner.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not write after finish", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("before");
+		renderer.finish();
+		const writtenCount = written.length;
+		renderer.write("after");
+
+		expect(written.length).toBe(writtenCount);
+	});
+
+	it("should add newline on finish if last char was not newline", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("no newline at end");
+		renderer.finish();
+
+		expect(written).toContain("\n");
+	});
+
+	it("should not add extra newline on finish if text ends with newline", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("ends with newline\n");
+		const countBefore = written.filter((w) => w === "\n").length;
+		renderer.finish();
+		const countAfter = written.filter((w) => w === "\n").length;
+
+		expect(countAfter).toBe(countBefore);
+	});
+
+	it("should print bottom border on finish", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("text");
+		renderer.finish();
+
+		// Last two console.log calls should be borders (top + bottom)
+		const borders = logged.filter((l) => l.includes("─"));
+		expect(borders.length).toBe(2);
+	});
+
+	it("should not finish if never started", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.finish();
+
+		// No borders should be printed
+		const borders = logged.filter((l) => l.includes("─"));
+		expect(borders.length).toBe(0);
+	});
+
+	it("should not finish twice", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("text");
+		renderer.finish();
+		const logCount = logged.length;
+		renderer.finish();
+
+		expect(logged.length).toBe(logCount);
+	});
+
+	it("success should finish stream and print success line", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("output");
+		renderer.success("Task done");
+
+		const successLine = logged.find((l) => l.includes("✔") && l.includes("Task done"));
+		expect(successLine).toBeDefined();
+	});
+
+	it("success should include elapsed time", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("output");
+		renderer.success();
+
+		const successLine = logged.find((l) => l.includes("✔"));
+		expect(successLine).toBeDefined();
+		// Should contain time in brackets
+		expect(successLine).toMatch(/\[.*\]/);
+	});
+
+	it("error should finish stream and print error line", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.write("output");
+		renderer.error("Something failed");
+
+		const errorLine = logged.find((l) => l.includes("✖") && l.includes("Something failed"));
+		expect(errorLine).toBeDefined();
+	});
+
+	it("error without streaming should still print error line", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		renderer.error("Failed before streaming");
+
+		const errorLine = logged.find((l) => l.includes("✖") && l.includes("Failed before streaming"));
+		expect(errorLine).toBeDefined();
+	});
+
+	it("isActive should reflect stream state", () => {
+		const spinner = createMockSpinner();
+		const renderer = new StreamRenderer(spinner as never);
+
+		expect(renderer.isActive).toBe(false);
+		renderer.write("text");
+		expect(renderer.isActive).toBe(true);
+		renderer.finish();
+		expect(renderer.isActive).toBe(false);
+	});
+});

--- a/cli/src/ui/stream.ts
+++ b/cli/src/ui/stream.ts
@@ -1,0 +1,77 @@
+import pc from "picocolors";
+import { formatDuration } from "./logger.ts";
+import type { ProgressSpinner } from "./spinner.ts";
+
+const STREAM_BORDER = pc.dim("─".repeat(60));
+
+/**
+ * Renders streamed AI text output to the terminal.
+ *
+ * Coordinates with ProgressSpinner: stops the spinner on first text chunk,
+ * displays a bordered text region, then provides success/error for final status.
+ */
+export class StreamRenderer {
+	private started = false;
+	private ended = false;
+	private startTime: number;
+	private lastCharWasNewline = true;
+
+	constructor(private spinner: ProgressSpinner) {
+		this.startTime = Date.now();
+	}
+
+	/**
+	 * Write a text chunk to stdout. Stops the spinner on the first call.
+	 */
+	write(text: string): void {
+		if (this.ended) return;
+
+		if (!this.started) {
+			this.started = true;
+			this.spinner.stop();
+			console.log(STREAM_BORDER);
+		}
+
+		process.stdout.write(text);
+		if (text.length > 0) {
+			this.lastCharWasNewline = text[text.length - 1] === "\n";
+		}
+	}
+
+	/**
+	 * Close the stream border. Called automatically by success/error.
+	 */
+	finish(): void {
+		if (!this.started || this.ended) return;
+		this.ended = true;
+
+		if (!this.lastCharWasNewline) {
+			process.stdout.write("\n");
+		}
+		console.log(STREAM_BORDER);
+	}
+
+	/**
+	 * Print success status with elapsed time
+	 */
+	success(message?: string): void {
+		this.finish();
+		const elapsed = formatDuration(Date.now() - this.startTime);
+		const text = message || "Done";
+		console.log(`${pc.green("✔")} ${text} ${pc.green(`[${elapsed}]`)}`);
+	}
+
+	/**
+	 * Print error status with elapsed time
+	 */
+	error(message?: string): void {
+		this.finish();
+		const elapsed = formatDuration(Date.now() - this.startTime);
+		const text = message || "Failed";
+		console.log(`${pc.red("✖")} ${text} ${pc.red(`[${elapsed}]`)}`);
+	}
+
+	get isActive(): boolean {
+		return this.started && !this.ended;
+	}
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add --stream-output flag to stream agent AI output to stdout during loop execution
- Adds a `--stream-output` CLI flag that, when set, streams raw AI text to stdout in real time instead of relying solely on spinner-based progress.
- In sequential mode, a new `StreamRenderer` class stops the spinner on the first chunk, wraps output in a bordered region, and prints a success/error line with elapsed time on completion.
- In parallel mode, each agent's streamed output is written to stdout prefixed with `[agent N]`.
- Both `runAgentInWorktree` and `runAgentInSandbox` call `executeStreaming` with an `onText` callback when streaming is enabled, falling back to `execute` otherwise.
- `ClaudeEngine.executeStreaming` is extended to accept an optional `onText` callback, using a new `extractAssistantTextFromStreamJson` utility to parse and forward assistant text from stream-json lines.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 194c908.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->