### PR TITLE
Add MiniMax engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ralphy --copilot    # GitHub Copilot
 ralphy --gemini     # Gemini CLI
+ralphy --minimax    # MiniMax through Claude Code
+```
+
+The MiniMax engine uses `MiniMax-M3` by default. Set its API key before running it:
+
+```bash
+export MINIMAX_API_KEY="..."
+ralphy --minimax "add feature"
 ```
 
 ### Model Override
@@ -355,6 +363,7 @@ ralphy --parallel --sandbox
 | Droid | `droid exec` | `--auto medium` | duration |
 | Copilot | `copilot` | `--yolo` | tokens |
 | Gemini | `gemini` | `--yolo` | tokens + cost |
+| MiniMax | `claude` | `--dangerously-skip-permissions` | tokens + cost |
 
 When an engine exits non-zero, ralphy includes the last lines of CLI output in the error message to make debugging easier.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,6 +77,14 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ralphy --copilot    # GitHub Copilot
 ralphy --gemini     # Gemini CLI
+ralphy --minimax    # MiniMax through Claude Code
+```
+
+The MiniMax engine uses `MiniMax-M3` by default. Set its API key before running it:
+
+```bash
+export MINIMAX_API_KEY="..."
+ralphy --minimax "add feature"
 ```
 
 ### Model Override
@@ -343,6 +351,7 @@ ralphy --parallel --sandbox
 | Droid | `droid exec` | `--auto medium` | duration |
 | Copilot | `copilot` | `--yolo` | tokens |
 | Gemini | `gemini` | `--yolo` | tokens + cost |
+| MiniMax | `claude` | `--dangerously-skip-permissions` | tokens + cost |
 
 When an engine exits non-zero, ralphy includes the last lines of CLI output in the error message to make debugging easier.
 

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -30,6 +30,7 @@ export function createProgram(): Command {
 		.option("--droid", "Use Factory Droid")
 		.option("--copilot", "Use GitHub Copilot")
 		.option("--gemini", "Use Gemini CLI")
+		.option("--minimax", "Use MiniMax through Claude Code")
 		.option("--dry-run", "Show what would be done without executing")
 		.option("--max-iterations <n>", "Maximum iterations (0 = unlimited)", "0")
 		.option("--max-retries <n>", "Maximum retries per task", "3")
@@ -98,6 +99,7 @@ export function parseArgs(args: string[]): {
 	else if (opts.droid) aiEngine = "droid";
 	else if (opts.copilot) aiEngine = "copilot";
 	else if (opts.gemini) aiEngine = "gemini";
+	else if (opts.minimax) aiEngine = "minimax";
 
 	// Determine model override (--sonnet is shortcut for --model sonnet)
 	const modelOverride = opts.sonnet ? "sonnet" : opts.model || undefined;

--- a/cli/src/engines/claude.ts
+++ b/cli/src/engines/claude.ts
@@ -18,10 +18,19 @@ export class ClaudeEngine extends BaseAIEngine {
 	name = "Claude Code";
 	cliCommand = "claude";
 
+	protected getModel(options?: EngineOptions): string | undefined {
+		return options?.modelOverride;
+	}
+
+	protected getEnvironment(_options?: EngineOptions): Record<string, string> | undefined {
+		return undefined;
+	}
+
 	async execute(prompt: string, workDir: string, options?: EngineOptions): Promise<AIResult> {
 		const args = ["--dangerously-skip-permissions", "--verbose", "--output-format", "stream-json"];
-		if (options?.modelOverride) {
-			args.push("--model", options.modelOverride);
+		const model = this.getModel(options);
+		if (model) {
+			args.push("--model", model);
 		}
 		// Add any additional engine-specific arguments
 		if (options?.engineArgs && options.engineArgs.length > 0) {
@@ -42,7 +51,7 @@ export class ClaudeEngine extends BaseAIEngine {
 			this.cliCommand,
 			args,
 			workDir,
-			undefined,
+			this.getEnvironment(options),
 			stdinContent,
 		);
 
@@ -89,8 +98,9 @@ export class ClaudeEngine extends BaseAIEngine {
 		options?: EngineOptions,
 	): Promise<AIResult> {
 		const args = ["--dangerously-skip-permissions", "--verbose", "--output-format", "stream-json"];
-		if (options?.modelOverride) {
-			args.push("--model", options.modelOverride);
+		const model = this.getModel(options);
+		if (model) {
+			args.push("--model", model);
 		}
 		// Add any additional engine-specific arguments
 		if (options?.engineArgs && options.engineArgs.length > 0) {
@@ -122,7 +132,7 @@ export class ClaudeEngine extends BaseAIEngine {
 					onProgress(step);
 				}
 			},
-			undefined,
+			this.getEnvironment(options),
 			stdinContent,
 		);
 

--- a/cli/src/engines/index.ts
+++ b/cli/src/engines/index.ts
@@ -8,6 +8,7 @@ export * from "./qwen.ts";
 export * from "./droid.ts";
 export * from "./copilot.ts";
 export * from "./gemini.ts";
+export * from "./minimax.ts";
 
 import { ClaudeEngine } from "./claude.ts";
 import { CodexEngine } from "./codex.ts";
@@ -15,6 +16,7 @@ import { CopilotEngine } from "./copilot.ts";
 import { CursorEngine } from "./cursor.ts";
 import { DroidEngine } from "./droid.ts";
 import { GeminiEngine } from "./gemini.ts";
+import { MiniMaxEngine } from "./minimax.ts";
 import { OpenCodeEngine } from "./opencode.ts";
 import { QwenEngine } from "./qwen.ts";
 import type { AIEngine, AIEngineName } from "./types.ts";
@@ -40,6 +42,8 @@ export function createEngine(name: AIEngineName): AIEngine {
 			return new CopilotEngine();
 		case "gemini":
 			return new GeminiEngine();
+		case "minimax":
+			return new MiniMaxEngine();
 		default:
 			throw new Error(`Unknown AI engine: ${name}`);
 	}

--- a/cli/src/engines/minimax.test.ts
+++ b/cli/src/engines/minimax.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { parseArgs } from "../cli/args.ts";
+import * as baseModule from "./base.ts";
+import { createEngine } from "./index.ts";
+import { MiniMaxEngine } from "./minimax.ts";
+
+const originalMiniMaxApiKey = process.env.MINIMAX_API_KEY;
+const originalAnthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}
+
+afterEach(() => {
+	restoreEnvironment("MINIMAX_API_KEY", originalMiniMaxApiKey);
+	restoreEnvironment("ANTHROPIC_AUTH_TOKEN", originalAnthropicAuthToken);
+});
+
+describe("MiniMaxEngine", () => {
+	it("registers the minimax CLI option and engine", () => {
+		const { options } = parseArgs(["node", "ralphy", "--minimax"]);
+		const engine = createEngine("minimax");
+
+		expect(options.aiEngine).toBe("minimax");
+		expect(engine).toBeInstanceOf(MiniMaxEngine);
+		expect(engine.name).toBe("MiniMax");
+		expect(engine.cliCommand).toBe("claude");
+	});
+
+	it("uses the default model and MiniMax environment", async () => {
+		process.env.MINIMAX_API_KEY = "test-key";
+		let capturedArgs: string[] = [];
+		let capturedEnvironment: Record<string, string> | undefined;
+
+		const spy = spyOn(baseModule, "execCommand").mockImplementation(
+			async (_command, args, _workDir, environment) => {
+				capturedArgs = args;
+				capturedEnvironment = environment;
+				return {
+					stdout: '{"type":"result","result":"Done","usage":{"input_tokens":1,"output_tokens":1}}',
+					stderr: "",
+					exitCode: 0,
+				};
+			},
+		);
+
+		await new MiniMaxEngine().execute("test", process.cwd());
+
+		const modelIndex = capturedArgs.indexOf("--model");
+		expect(capturedArgs[modelIndex + 1]).toBe("MiniMax-M3");
+		expect(capturedEnvironment).toEqual({
+			ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
+			ANTHROPIC_MODEL: "MiniMax-M3",
+			ANTHROPIC_SMALL_FAST_MODEL: "MiniMax-M3",
+			ANTHROPIC_AUTH_TOKEN: "test-key",
+		});
+
+		spy.mockRestore();
+	});
+
+	it("applies model overrides to command and environment", async () => {
+		process.env.ANTHROPIC_AUTH_TOKEN = "test-token";
+		restoreEnvironment("MINIMAX_API_KEY", undefined);
+		let capturedArgs: string[] = [];
+		let capturedEnvironment: Record<string, string> | undefined;
+
+		const spy = spyOn(baseModule, "execCommand").mockImplementation(
+			async (_command, args, _workDir, environment) => {
+				capturedArgs = args;
+				capturedEnvironment = environment;
+				return {
+					stdout: '{"type":"result","result":"Done","usage":{"input_tokens":1,"output_tokens":1}}',
+					stderr: "",
+					exitCode: 0,
+				};
+			},
+		);
+
+		await new MiniMaxEngine().execute("test", process.cwd(), {
+			modelOverride: "custom-model",
+		});
+
+		const modelIndex = capturedArgs.indexOf("--model");
+		expect(capturedArgs[modelIndex + 1]).toBe("custom-model");
+		expect(capturedEnvironment?.ANTHROPIC_MODEL).toBe("custom-model");
+		expect(capturedEnvironment?.ANTHROPIC_SMALL_FAST_MODEL).toBe("custom-model");
+		expect(capturedEnvironment?.ANTHROPIC_AUTH_TOKEN).toBe("test-token");
+
+		spy.mockRestore();
+	});
+
+	it("uses the same environment for streaming execution", async () => {
+		process.env.MINIMAX_API_KEY = "test-key";
+		let capturedEnvironment: Record<string, string> | undefined;
+
+		const spy = spyOn(baseModule, "execCommandStreaming").mockImplementation(
+			async (_command, _args, _workDir, onLine, environment) => {
+				capturedEnvironment = environment;
+				onLine('{"type":"result","result":"Done","usage":{"input_tokens":1,"output_tokens":1}}');
+				return { exitCode: 0 };
+			},
+		);
+
+		await new MiniMaxEngine().executeStreaming("test", process.cwd(), () => {});
+
+		expect(capturedEnvironment?.ANTHROPIC_BASE_URL).toBe("https://api.minimax.io/anthropic");
+		expect(capturedEnvironment?.ANTHROPIC_AUTH_TOKEN).toBe("test-key");
+
+		spy.mockRestore();
+	});
+});

--- a/cli/src/engines/minimax.ts
+++ b/cli/src/engines/minimax.ts
@@ -1,0 +1,28 @@
+import { ClaudeEngine } from "./claude.ts";
+import type { EngineOptions } from "./types.ts";
+
+const DEFAULT_MODEL = "MiniMax-M3";
+const ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic";
+
+/**
+ * MiniMax AI Engine using the Anthropic-compatible Claude Code transport.
+ */
+export class MiniMaxEngine extends ClaudeEngine {
+	name = "MiniMax";
+
+	protected getModel(options?: EngineOptions): string {
+		return options?.modelOverride ?? DEFAULT_MODEL;
+	}
+
+	protected getEnvironment(options?: EngineOptions): Record<string, string> {
+		const model = this.getModel(options);
+		const authToken = process.env.MINIMAX_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN;
+
+		return {
+			ANTHROPIC_BASE_URL,
+			ANTHROPIC_MODEL: model,
+			ANTHROPIC_SMALL_FAST_MODEL: model,
+			...(authToken ? { ANTHROPIC_AUTH_TOKEN: authToken } : {}),
+		};
+	}
+}

--- a/cli/src/engines/types.ts
+++ b/cli/src/engines/types.ts
@@ -58,4 +58,5 @@ export type AIEngineName =
 	| "qwen"
 	| "droid"
 	| "copilot"
-	| "gemini";
+	| "gemini"
+	| "minimax";


### PR DESCRIPTION
Reason: Add first-class MiniMax engine support through the Claude Code transport.

## Changes

- add `--minimax` engine selection with `MiniMax-M3` as the default model
- route Claude Code requests through the MiniMax endpoint and map `MINIMAX_API_KEY` to bearer authentication
- add focused engine tests and usage documentation

## Checks

- `bun test src/engines/minimax.test.ts`
- `bun test`
- `bun run build`
- `bunx biome check src/cli/args.ts src/engines/claude.ts src/engines/index.ts src/engines/types.ts src/engines/minimax.ts src/engines/minimax.test.ts`
- `git diff --check origin/main...HEAD`

`bun run check` continues to report existing lint errors in execution and telemetry files outside this change.
