### PR TITLE
Add MiniMax engine with global and CN regional endpoint selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,28 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ralphy --copilot    # GitHub Copilot
 ralphy --gemini     # Gemini CLI
+ralphy --minimax    # MiniMax through Claude Code
 ```
+
+The MiniMax engine uses `MiniMax-M3` by default and talks to the
+Anthropic-compatible MiniMax endpoint. Set its API key before running it:
+
+```bash
+export MINIMAX_API_KEY="..."
+ralphy --minimax "add feature"
+```
+
+MiniMax is available on two platforms with separate hosts. Pick one with
+`MINIMAX_REGION` (defaults to `global_en`):
+
+```bash
+export MINIMAX_REGION="global_en"   # https://api.minimax.io/anthropic
+export MINIMAX_REGION="cn_zh"       # https://api.minimaxi.com/anthropic
+```
+
+`MINIMAX_BASE_URL` overrides the region when you need a custom or proxied
+endpoint. Use `--model` to select another MiniMax model, for example
+`ralphy --minimax --model MiniMax-M2.7 "add feature"`.
 
 ### Model Override
 
@@ -355,6 +376,7 @@ ralphy --parallel --sandbox
 | Droid | `droid exec` | `--auto medium` | duration |
 | Copilot | `copilot` | `--yolo` | tokens |
 | Gemini | `gemini` | `--yolo` | tokens + cost |
+| MiniMax | `claude` | `--dangerously-skip-permissions` | tokens + cost |
 
 When an engine exits non-zero, ralphy includes the last lines of CLI output in the error message to make debugging easier.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,7 +77,28 @@ ralphy --qwen       # Qwen-Code
 ralphy --droid      # Factory Droid
 ralphy --copilot    # GitHub Copilot
 ralphy --gemini     # Gemini CLI
+ralphy --minimax    # MiniMax through Claude Code
 ```
+
+The MiniMax engine uses `MiniMax-M3` by default and talks to the
+Anthropic-compatible MiniMax endpoint. Set its API key before running it:
+
+```bash
+export MINIMAX_API_KEY="..."
+ralphy --minimax "add feature"
+```
+
+MiniMax is available on two platforms with separate hosts. Pick one with
+`MINIMAX_REGION` (defaults to `global_en`):
+
+```bash
+export MINIMAX_REGION="global_en"   # https://api.minimax.io/anthropic
+export MINIMAX_REGION="cn_zh"       # https://api.minimaxi.com/anthropic
+```
+
+`MINIMAX_BASE_URL` overrides the region when you need a custom or proxied
+endpoint. Use `--model` to select another MiniMax model, for example
+`ralphy --minimax --model MiniMax-M2.7 "add feature"`.
 
 ### Model Override
 
@@ -343,6 +364,7 @@ ralphy --parallel --sandbox
 | Droid | `droid exec` | `--auto medium` | duration |
 | Copilot | `copilot` | `--yolo` | tokens |
 | Gemini | `gemini` | `--yolo` | tokens + cost |
+| MiniMax | `claude` | `--dangerously-skip-permissions` | tokens + cost |
 
 When an engine exits non-zero, ralphy includes the last lines of CLI output in the error message to make debugging easier.
 

--- a/cli/src/cli/args.ts
+++ b/cli/src/cli/args.ts
@@ -30,6 +30,7 @@ export function createProgram(): Command {
 		.option("--droid", "Use Factory Droid")
 		.option("--copilot", "Use GitHub Copilot")
 		.option("--gemini", "Use Gemini CLI")
+		.option("--minimax", "Use MiniMax through Claude Code")
 		.option("--dry-run", "Show what would be done without executing")
 		.option("--max-iterations <n>", "Maximum iterations (0 = unlimited)", "0")
 		.option("--max-retries <n>", "Maximum retries per task", "3")
@@ -98,6 +99,7 @@ export function parseArgs(args: string[]): {
 	else if (opts.droid) aiEngine = "droid";
 	else if (opts.copilot) aiEngine = "copilot";
 	else if (opts.gemini) aiEngine = "gemini";
+	else if (opts.minimax) aiEngine = "minimax";
 
 	// Determine model override (--sonnet is shortcut for --model sonnet)
 	const modelOverride = opts.sonnet ? "sonnet" : opts.model || undefined;

--- a/cli/src/engines/claude.ts
+++ b/cli/src/engines/claude.ts
@@ -18,10 +18,26 @@ export class ClaudeEngine extends BaseAIEngine {
 	name = "Claude Code";
 	cliCommand = "claude";
 
+	/**
+	 * Model passed to the CLI. Subclasses can provide their own default.
+	 */
+	protected getModel(options?: EngineOptions): string | undefined {
+		return options?.modelOverride;
+	}
+
+	/**
+	 * Extra environment variables for the CLI. Subclasses can point the
+	 * Anthropic-compatible transport at a different endpoint.
+	 */
+	protected getEnvironment(_options?: EngineOptions): Record<string, string> | undefined {
+		return undefined;
+	}
+
 	async execute(prompt: string, workDir: string, options?: EngineOptions): Promise<AIResult> {
 		const args = ["--dangerously-skip-permissions", "--verbose", "--output-format", "stream-json"];
-		if (options?.modelOverride) {
-			args.push("--model", options.modelOverride);
+		const model = this.getModel(options);
+		if (model) {
+			args.push("--model", model);
 		}
 		// Add any additional engine-specific arguments
 		if (options?.engineArgs && options.engineArgs.length > 0) {
@@ -42,7 +58,7 @@ export class ClaudeEngine extends BaseAIEngine {
 			this.cliCommand,
 			args,
 			workDir,
-			undefined,
+			this.getEnvironment(options),
 			stdinContent,
 		);
 
@@ -89,8 +105,9 @@ export class ClaudeEngine extends BaseAIEngine {
 		options?: EngineOptions,
 	): Promise<AIResult> {
 		const args = ["--dangerously-skip-permissions", "--verbose", "--output-format", "stream-json"];
-		if (options?.modelOverride) {
-			args.push("--model", options.modelOverride);
+		const model = this.getModel(options);
+		if (model) {
+			args.push("--model", model);
 		}
 		// Add any additional engine-specific arguments
 		if (options?.engineArgs && options.engineArgs.length > 0) {
@@ -122,7 +139,7 @@ export class ClaudeEngine extends BaseAIEngine {
 					onProgress(step);
 				}
 			},
-			undefined,
+			this.getEnvironment(options),
 			stdinContent,
 		);
 

--- a/cli/src/engines/index.ts
+++ b/cli/src/engines/index.ts
@@ -8,6 +8,7 @@ export * from "./qwen.ts";
 export * from "./droid.ts";
 export * from "./copilot.ts";
 export * from "./gemini.ts";
+export * from "./minimax.ts";
 
 import { ClaudeEngine } from "./claude.ts";
 import { CodexEngine } from "./codex.ts";
@@ -15,6 +16,7 @@ import { CopilotEngine } from "./copilot.ts";
 import { CursorEngine } from "./cursor.ts";
 import { DroidEngine } from "./droid.ts";
 import { GeminiEngine } from "./gemini.ts";
+import { MiniMaxEngine } from "./minimax.ts";
 import { OpenCodeEngine } from "./opencode.ts";
 import { QwenEngine } from "./qwen.ts";
 import type { AIEngine, AIEngineName } from "./types.ts";
@@ -40,6 +42,8 @@ export function createEngine(name: AIEngineName): AIEngine {
 			return new CopilotEngine();
 		case "gemini":
 			return new GeminiEngine();
+		case "minimax":
+			return new MiniMaxEngine();
 		default:
 			throw new Error(`Unknown AI engine: ${name}`);
 	}

--- a/cli/src/engines/minimax.test.ts
+++ b/cli/src/engines/minimax.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { parseArgs } from "../cli/args.ts";
+import * as baseModule from "./base.ts";
+import { createEngine } from "./index.ts";
+import {
+	DEFAULT_MINIMAX_REGION,
+	MINIMAX_REGION_BASE_URLS,
+	MiniMaxEngine,
+	resolveMiniMaxBaseUrl,
+	resolveMiniMaxRegion,
+} from "./minimax.ts";
+
+const TRACKED_ENV_VARS = [
+	"MINIMAX_API_KEY",
+	"MINIMAX_REGION",
+	"MINIMAX_BASE_URL",
+	"ANTHROPIC_AUTH_TOKEN",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>(
+	TRACKED_ENV_VARS.map((name) => [name, process.env[name]]),
+);
+
+function setEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+	} else {
+		process.env[name] = value;
+	}
+}
+
+afterEach(() => {
+	for (const [name, value] of originalEnv) {
+		setEnv(name, value);
+	}
+});
+
+function mockExecCommand(): {
+	spy: ReturnType<typeof spyOn>;
+	captured: { args: string[]; env?: Record<string, string> };
+} {
+	const captured: { args: string[]; env?: Record<string, string> } = { args: [] };
+	const spy = spyOn(baseModule, "execCommand").mockImplementation(
+		async (_command, args, _workDir, env) => {
+			captured.args = args;
+			captured.env = env;
+			return {
+				stdout: '{"type":"result","result":"Done","usage":{"input_tokens":1,"output_tokens":1}}',
+				stderr: "",
+				exitCode: 0,
+			};
+		},
+	);
+
+	return { spy, captured };
+}
+
+describe("MiniMax region resolution", () => {
+	it("exposes an endpoint for every supported region", () => {
+		expect(MINIMAX_REGION_BASE_URLS).toEqual({
+			global_en: "https://api.minimax.io/anthropic",
+			cn_zh: "https://api.minimaxi.com/anthropic",
+		});
+	});
+
+	it("defaults to the global region", () => {
+		expect(resolveMiniMaxRegion(undefined)).toBe(DEFAULT_MINIMAX_REGION);
+		expect(resolveMiniMaxRegion("")).toBe("global_en");
+		expect(resolveMiniMaxBaseUrl({})).toBe("https://api.minimax.io/anthropic");
+	});
+
+	it("selects the CN endpoint when the CN region is configured", () => {
+		expect(resolveMiniMaxBaseUrl({ MINIMAX_REGION: "cn_zh" })).toBe(
+			"https://api.minimaxi.com/anthropic",
+		);
+	});
+
+	it("accepts region aliases and mixed formatting", () => {
+		expect(resolveMiniMaxRegion("CN")).toBe("cn_zh");
+		expect(resolveMiniMaxRegion(" cn-zh ")).toBe("cn_zh");
+		expect(resolveMiniMaxRegion("Global")).toBe("global_en");
+		expect(resolveMiniMaxRegion("global-en")).toBe("global_en");
+	});
+
+	it("rejects unknown regions", () => {
+		expect(() => resolveMiniMaxRegion("moon")).toThrow(/Unknown MINIMAX_REGION/);
+	});
+
+	it("lets an explicit base URL win over the region", () => {
+		expect(
+			resolveMiniMaxBaseUrl({
+				MINIMAX_REGION: "cn_zh",
+				MINIMAX_BASE_URL: "https://proxy.internal/anthropic/",
+			}),
+		).toBe("https://proxy.internal/anthropic");
+	});
+});
+
+describe("MiniMaxEngine", () => {
+	it("registers the minimax CLI option and engine", () => {
+		const { options } = parseArgs(["node", "ralphy", "--minimax"]);
+		const engine = createEngine("minimax");
+
+		expect(options.aiEngine).toBe("minimax");
+		expect(engine).toBeInstanceOf(MiniMaxEngine);
+		expect(engine.name).toBe("MiniMax");
+		expect(engine.cliCommand).toBe("claude");
+	});
+
+	it("uses the default model and the global endpoint", async () => {
+		setEnv("MINIMAX_API_KEY", "test-key");
+		setEnv("MINIMAX_REGION", undefined);
+		setEnv("MINIMAX_BASE_URL", undefined);
+		const { spy, captured } = mockExecCommand();
+
+		await new MiniMaxEngine().execute("test", process.cwd());
+
+		const modelIndex = captured.args.indexOf("--model");
+		expect(captured.args[modelIndex + 1]).toBe("MiniMax-M3");
+		expect(captured.env).toEqual({
+			ANTHROPIC_BASE_URL: "https://api.minimax.io/anthropic",
+			ANTHROPIC_MODEL: "MiniMax-M3",
+			ANTHROPIC_SMALL_FAST_MODEL: "MiniMax-M3",
+			ANTHROPIC_AUTH_TOKEN: "test-key",
+		});
+
+		spy.mockRestore();
+	});
+
+	it("routes to the CN endpoint when the CN region is selected", async () => {
+		setEnv("MINIMAX_API_KEY", "test-key");
+		setEnv("MINIMAX_REGION", "cn_zh");
+		setEnv("MINIMAX_BASE_URL", undefined);
+		const { spy, captured } = mockExecCommand();
+
+		await new MiniMaxEngine().execute("test", process.cwd());
+
+		expect(captured.env?.ANTHROPIC_BASE_URL).toBe("https://api.minimaxi.com/anthropic");
+
+		spy.mockRestore();
+	});
+
+	it("applies model overrides to command and environment", async () => {
+		setEnv("MINIMAX_API_KEY", undefined);
+		setEnv("ANTHROPIC_AUTH_TOKEN", "test-token");
+		const { spy, captured } = mockExecCommand();
+
+		await new MiniMaxEngine().execute("test", process.cwd(), {
+			modelOverride: "MiniMax-M2.7",
+		});
+
+		const modelIndex = captured.args.indexOf("--model");
+		expect(captured.args[modelIndex + 1]).toBe("MiniMax-M2.7");
+		expect(captured.env?.ANTHROPIC_MODEL).toBe("MiniMax-M2.7");
+		expect(captured.env?.ANTHROPIC_SMALL_FAST_MODEL).toBe("MiniMax-M2.7");
+		expect(captured.env?.ANTHROPIC_AUTH_TOKEN).toBe("test-token");
+
+		spy.mockRestore();
+	});
+
+	it("uses the configured endpoint for streaming execution", async () => {
+		setEnv("MINIMAX_API_KEY", "test-key");
+		setEnv("MINIMAX_REGION", "cn");
+		setEnv("MINIMAX_BASE_URL", undefined);
+		let capturedEnv: Record<string, string> | undefined;
+
+		const spy = spyOn(baseModule, "execCommandStreaming").mockImplementation(
+			async (_command, _args, _workDir, onLine, env) => {
+				capturedEnv = env;
+				onLine('{"type":"result","result":"Done","usage":{"input_tokens":1,"output_tokens":1}}');
+				return { exitCode: 0 };
+			},
+		);
+
+		await new MiniMaxEngine().executeStreaming("test", process.cwd(), () => {});
+
+		expect(capturedEnv?.ANTHROPIC_BASE_URL).toBe("https://api.minimaxi.com/anthropic");
+		expect(capturedEnv?.ANTHROPIC_AUTH_TOKEN).toBe("test-key");
+
+		spy.mockRestore();
+	});
+});

--- a/cli/src/engines/minimax.ts
+++ b/cli/src/engines/minimax.ts
@@ -1,0 +1,93 @@
+import { ClaudeEngine } from "./claude.ts";
+import type { EngineOptions } from "./types.ts";
+
+/** Default MiniMax model used when no `--model` override is given */
+const DEFAULT_MODEL = "MiniMax-M3";
+
+/**
+ * Anthropic-compatible endpoint for each supported MiniMax region.
+ * The global and CN platforms are separate deployments with their own hosts,
+ * so the region has to be selectable instead of hard-coded.
+ */
+export const MINIMAX_REGION_BASE_URLS = {
+	global_en: "https://api.minimax.io/anthropic",
+	cn_zh: "https://api.minimaxi.com/anthropic",
+} as const;
+
+export type MiniMaxRegion = keyof typeof MINIMAX_REGION_BASE_URLS;
+
+/** Region used when nothing is configured */
+export const DEFAULT_MINIMAX_REGION: MiniMaxRegion = "global_en";
+
+/** Accepted spellings for each region, including short aliases */
+const REGION_ALIASES: Record<string, MiniMaxRegion> = {
+	global_en: "global_en",
+	global: "global_en",
+	en: "global_en",
+	intl: "global_en",
+	cn_zh: "cn_zh",
+	cn: "cn_zh",
+	zh: "cn_zh",
+};
+
+/**
+ * Normalize a configured region name to a supported region key.
+ * Throws on unknown values so a typo fails fast instead of silently
+ * falling back to the wrong regional endpoint.
+ */
+export function resolveMiniMaxRegion(region?: string): MiniMaxRegion {
+	const normalized = region
+		?.trim()
+		.toLowerCase()
+		.replace(/[-\s]+/g, "_");
+	if (!normalized) {
+		return DEFAULT_MINIMAX_REGION;
+	}
+
+	const resolved = REGION_ALIASES[normalized];
+	if (!resolved) {
+		const supported = Object.keys(MINIMAX_REGION_BASE_URLS).join(", ");
+		throw new Error(`Unknown MINIMAX_REGION "${region}". Supported regions: ${supported}`);
+	}
+
+	return resolved;
+}
+
+/**
+ * Resolve the Anthropic-compatible base URL for MiniMax.
+ * `MINIMAX_BASE_URL` wins so a custom or proxied endpoint stays possible,
+ * otherwise the URL comes from `MINIMAX_REGION`.
+ */
+export function resolveMiniMaxBaseUrl(
+	env: Record<string, string | undefined> = process.env,
+): string {
+	const explicitBaseUrl = env.MINIMAX_BASE_URL?.trim();
+	if (explicitBaseUrl) {
+		return explicitBaseUrl.replace(/\/+$/, "");
+	}
+
+	return MINIMAX_REGION_BASE_URLS[resolveMiniMaxRegion(env.MINIMAX_REGION)];
+}
+
+/**
+ * MiniMax AI Engine using the Anthropic-compatible Claude Code transport.
+ */
+export class MiniMaxEngine extends ClaudeEngine {
+	name = "MiniMax";
+
+	protected getModel(options?: EngineOptions): string {
+		return options?.modelOverride ?? DEFAULT_MODEL;
+	}
+
+	protected getEnvironment(options?: EngineOptions): Record<string, string> {
+		const model = this.getModel(options);
+		const authToken = process.env.MINIMAX_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN;
+
+		return {
+			ANTHROPIC_BASE_URL: resolveMiniMaxBaseUrl(),
+			ANTHROPIC_MODEL: model,
+			ANTHROPIC_SMALL_FAST_MODEL: model,
+			...(authToken ? { ANTHROPIC_AUTH_TOKEN: authToken } : {}),
+		};
+	}
+}

--- a/cli/src/engines/types.ts
+++ b/cli/src/engines/types.ts
@@ -58,4 +58,5 @@ export type AIEngineName =
 	| "qwen"
 	| "droid"
 	| "copilot"
-	| "gemini";
+	| "gemini"
+	| "minimax";


### PR DESCRIPTION
Reason: MiniMax serves the global and CN platforms from separate hosts, so the endpoint has to be selectable instead of fixed to one region.

## Changes

- add a `--minimax` engine that reuses the existing `claude` CLI transport with `MiniMax-M3` as the default model
- resolve the endpoint from `MINIMAX_REGION` so both supported regions are covered:
  - `global_en` -> `https://api.minimax.io/anthropic`
  - `cn_zh` -> `https://api.minimaxi.com/anthropic`
- let `MINIMAX_BASE_URL` override the region for a custom or proxied endpoint, and reject unknown region names instead of silently falling back to the wrong host
- map `MINIMAX_API_KEY` (falling back to `ANTHROPIC_AUTH_TOKEN`) to bearer authentication
- add `getModel` / `getEnvironment` hooks to the existing engine class so a subclass can set the model and endpoint without duplicating the execute paths; the default behavior is unchanged because the base hooks return the previous values
- add engine tests for both regions, alias handling and the base URL override, and document the variables in both READMEs

## Checks

- `bun test` (123 pass)
- `bun test src/engines/minimax.test.ts` (11 pass)
- `bunx biome check src/cli/args.ts src/engines/claude.ts src/engines/index.ts src/engines/types.ts src/engines/minimax.ts src/engines/minimax.test.ts`
- `bun run build`
- `git diff --check`

`bun run check` rewrites the whole repository and reports lint errors that already exist in files outside this change, so the lint run was scoped to the changed files.
